### PR TITLE
Add LS1046A DPAA1/FMan networking and eMMC support

### DIFF
--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -180,7 +180,7 @@ jobs:
           cp data/config.boot.default vyos-build/data/live-build-config/includes.chroot/opt/vyatta/etc/
           cp data/config.boot.dhcp vyos-build/data/live-build-config/includes.chroot/opt/vyatta/etc/
           # fix kernel config https://github.com/vyos/vyos-build/pull/1121
-          #patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-001-kernel_config.patch
+          patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-001-kernel_config.patch
           # https://github.com/vyos/vyos-build/commit/88f11dc01bb676bf652512d6bf23ba0f10f5101f
           #patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-003-fix_hardcoded_x86_64.patch
           # fix on https://github.com/vyos/vyos-build/commit/82a40e68c7e4b3ea45fb2bbc4a1a7cff92e41942
@@ -194,6 +194,24 @@ jobs:
           #patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-008-fix_live_boot_initramfs_link.patch
           # https://github.com/vyos/vyos-build/commit/ff2a5df902ca31d51eda6744c94cb257d162fcfc
           #patch --no-backup-if-mismatch -p1 -d vyos-build < data/vyos-build-009-live_boot_serial_console_device.patch
+          # LS1046A: inject board-specific kernel config (DPAA1/FMan networking + console)
+          DEFCONFIG=vyos-build/scripts/package-build/linux-kernel/arch/arm64/configs/vyos_defconfig
+          cat >> "$DEFCONFIG" << 'KCONFIG'
+# === LS1046A / NXP Layerscape DPAA1 (Mono Gateway DK) ===
+CONFIG_FSL_FMAN=y
+CONFIG_FSL_DPAA=y
+CONFIG_FSL_DPAA_ETH=y
+CONFIG_FSL_BMAN=y
+CONFIG_FSL_QMAN=y
+CONFIG_FSL_PAMU=y
+CONFIG_SERIAL_8250_OF=y
+KCONFIG
+          echo "Appended LS1046A DPAA config to defconfig"
+          # Fix console: revert ttyAMA0 -> ttyS0 for LS1046A serial (8250 UART)
+          SERIAL_HOOK=vyos-build/data/live-build-config/hooks/live/01-live-serial.binary
+          sed -i 's/ttyAMA0/ttyS0/g' "$SERIAL_HOOK" 2>/dev/null || true
+          GRUB_ENTRY=vyos-build/data/live-build-config/includes.chroot/opt/vyatta/etc/grub/default-union-grub-entry
+          sed -i 's/ttyAMA0/ttyS0/g' "$GRUB_ENTRY" 2>/dev/null || true
           # https://github.com/vyos/vyos-build/blob/fd737172f1068870fe1ededbe9b2ed4a86663acd/data/live-build-config/includes.chroot/var/lib/shim-signed/mok/README.md
           if [ -f data/mok/MOK.key ]; then
             # https://github.com/vyos/vyos-build/commit/d552f7f8c38d7ad3bd28d9019a58b57e41b07f0b

--- a/data/vyos-build-010-ls1046a_dpaa_networking.patch
+++ b/data/vyos-build-010-ls1046a_dpaa_networking.patch
@@ -1,0 +1,30 @@
+diff --git a/scripts/package-build/linux-kernel/arch/arm64/configs/vyos_defconfig b/scripts/package-build/linux-kernel/arch/arm64/configs/vyos_defconfig
+--- a/scripts/package-build/linux-kernel/arch/arm64/configs/vyos_defconfig
++++ b/scripts/package-build/linux-kernel/arch/arm64/configs/vyos_defconfig
+@@ -1,6 +1,34 @@
++# LS1046A / NXP Layerscape DPAA1 Networking and FMan support
++# Required for Mono Gateway Development Kit (fsl,ls1046a)
++CONFIG_FSL_FMAN=y
++CONFIG_FSL_DPAA=y
++CONFIG_FSL_DPAA_ETH=y
++CONFIG_FSL_DPAA_MACSEC=y
++CONFIG_FSL_BMAN=y
++CONFIG_FSL_BMAN_TEST=n
++CONFIG_FSL_QMAN=y
++CONFIG_FSL_QMAN_TEST=n
++CONFIG_FSL_DPAA_CHECKING=n
++# LS1046A eMMC (eSDHC) - also covered by kernel_config.patch but ensure =m
++CONFIG_MMC_SDHCI_OF_ESDHC=m
++# LS1046A Serial (8250-of DT binding) - ensure ttyS0 works
++CONFIG_SERIAL_8250_OF=y
++# LS1046A DMA engine for eSDHC HS200
++CONFIG_FSL_EDMA=m
++# LS1046A FMan firmware loading from MTD
++CONFIG_MTD=y
++CONFIG_MTD_SPI_NOR=m
++CONFIG_SPI=y
++CONFIG_SPI_FSL_DSPI=y
++# LS1046A QMAN/BMAN portal
++CONFIG_FSL_PAMU=y
++# CDX bus for LS1046A hardware offload
++CONFIG_CDX_BUS=y


### PR DESCRIPTION
## Changes for NXP LS1046A (Mono Gateway Development Kit)

### Blockers fixed:
1. **eMMC boot** — re-enable `vyos-build-001-kernel_config.patch` (adds `CONFIG_MMC_SDHCI_OF_ESDHC=m`)
2. **Serial console** — revert `ttyAMA0 → ttyS0` (LS1046A uses 8250 UART, not PL011)
3. **DPAA1 networking** — inject LS1046A kernel config:
   - `CONFIG_FSL_FMAN=y`
   - `CONFIG_FSL_DPAA=y`
   - `CONFIG_FSL_DPAA_ETH=y`
   - `CONFIG_FSL_BMAN=y`, `CONFIG_FSL_QMAN=y`, `CONFIG_FSL_PAMU=y`

### Board:
- NXP LS1046A SoC (QorIQ Layerscape)
- 4× Cortex-A72 @ 1.8GHz
- 5× Ethernet via DPAA1/FMan (eth0–eth4)
- eMMC via Freescale eSDHC