### PR TITLE
dtb: add &bportals cell-index overlay to mono-gateway-dk.dts

### DIFF
--- a/data/dtb/mono-gateway-dk.dts
+++ b/data/dtb/mono-gateway-dk.dts
@@ -673,25 +673,60 @@ managed = "in-band-status";
  * - fsl,cgrid-range: Congestion Group ID allocation for DPDK
  */
 &qportals {
-	qman-fqids@0 {
-		compatible = "fsl,fqid-range";
-		fsl,fqid-range = <256 256>;
-	};
+qman-fqids@0 {
+compatible = "fsl,fqid-range";
+fsl,fqid-range = <256 256>;
+};
 
-	qman-fqids@1 {
-		compatible = "fsl,fqid-range";
-		fsl,fqid-range = <32768 32768>;
-	};
+qman-fqids@1 {
+compatible = "fsl,fqid-range";
+fsl,fqid-range = <32768 32768>;
+};
 
-	qman-pools@0 {
-		compatible = "fsl,pool-channel-range";
-		fsl,pool-channel-range = <0x401 0xf>;
-	};
+qman-pools@0 {
+compatible = "fsl,pool-channel-range";
+fsl,pool-channel-range = <0x401 0xf>;
+};
 
-	qman-cgrids@0 {
-		compatible = "fsl,cgrid-range";
-		fsl,cgrid-range = <0 256>;
-	};
+qman-cgrids@0 {
+compatible = "fsl,cgrid-range";
+fsl,cgrid-range = <0 256>;
+};
+};
+
+/*
+ * BMan portal cell-index assignments (from NXP SDK qoriq-bman-portals-sdk.dtsi).
+ *
+ * Required by the ASK fsl_qbman staging driver's bman_driver.c parse_pcfg(),
+ * which refuses any bman-portal node without a cell-index property:
+ *     "Can't get /soc/bman-portals@.../bman-portal@X property 'cell-index'"
+ *     "No BMan portals available!"
+ *
+ * Upstream arch/arm64/boot/dts/freescale/qoriq-bman-portals.dtsi leaves
+ * cell-index unset (its comment says "bootloader fix-ups are expected to
+ * provide cell-index"). U-Boot on the Mono Gateway does not patch these,
+ * so we must supply them in the board DTS.
+ *
+ * Also declares the BPID allocation range consumed by fsl_bpid_range_init()
+ * (drivers/staging/fsl_qbman/bman_driver.c), needed for DPDK/USDPAA buffer
+ * pool allocation.
+ */
+&bportals {
+bman-portal@0     { cell-index = <0>; };
+bman-portal@10000 { cell-index = <1>; };
+bman-portal@20000 { cell-index = <2>; };
+bman-portal@30000 { cell-index = <3>; };
+bman-portal@40000 { cell-index = <4>; };
+bman-portal@50000 { cell-index = <5>; };
+bman-portal@60000 { cell-index = <6>; };
+bman-portal@70000 { cell-index = <7>; };
+bman-portal@80000 { cell-index = <8>; };
+bman-portal@90000 { cell-index = <9>; };
+
+bman-bpids@0 {
+compatible = "fsl,bpid-range";
+fsl,bpid-range = <32 32>;
+};
 };
 
 /*


### PR DESCRIPTION
## Summary

Live-boot verification of the PR #32 ISO on the Mono Gateway showed the kernel boot advanced past the prior DTB-staleness panic but halted early BMan initialization with:

```
Can't get /soc/bman-portals@.../bman-portal@X property 'cell-index'
No BMan portals available!
```

## Root cause

The ASK `fsl_qbman` staging driver's `bman_driver.c` `parse_pcfg()` refuses to probe any `bman-portal` node without a `cell-index` property. Upstream `arch/arm64/boot/dts/freescale/qoriq-bman-portals.dtsi` (included via `fsl-ls1046a.dtsi`) leaves `cell-index` unset — its comment explicitly says *"bootloader fix-ups are expected to provide cell-index"*. U-Boot on the Mono Gateway does not patch these, so the DTS we build must supply them.

QMan already works out of the box because upstream `qoriq-qman-portals.dtsi` provides `cell-index` on the `qman-portal@N` nodes; only BMan is missing.

## Fix

Add an inline `&bportals { ... }` overlay in `data/dtb/mono-gateway-dk.dts` modelled on the existing `&qportals` overlay right above it. It assigns `cell-index = 0..9` to the ten `bman-portal@N` nodes and declares the `fsl,bpid-range` node consumed by `fsl_bpid_range_init()` for DPDK/USDPAA buffer-pool allocation.

Content is sourced verbatim from NXP's SDK `qoriq-bman-portals-sdk.dtsi`.

## Companion PR

The kernel producer repo ships the canonical SDK DTSIs as well so board DTS files that prefer `#include` over inline overlays can use them: mihakralj/lts_6.6_ls1046a#1.

## Verification plan

After merge: rebuild ISO with `./bin/build-local.sh iso-live`, redeploy to LXC 200 `/srv/tftp/`, re-run `dev_boot_live` on the Mono Gateway and confirm BMan probes succeed ("Bman portals initialised") and the DPAA ethernet drivers come up.