### PR TITLE
VyOS docs refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,4 @@ _fixup_bash_check.sh
 
 # Extracted ISO / build-output dirs (large; never commit)
 vyos-*-rolling-LS1046A-arm64/
+/.obsidian

--- a/FIRMWARE.md
+++ b/FIRMWARE.md
@@ -1,0 +1,614 @@
+# How-to: Update firmware of the Mono Gateway Development Kit
+
+The primary source of truth for the Mono firmware is the [Mono gateway development kit - flashing-firmware](https://docs.mono.si/gateway-development-kit/flashing-firmware). This documentation builds on this foundation, and addresses the quirks.
+
+\*\*\* WARNING: ONLY UPDATE THE FIRMWARE ON ONE STORAGE DEVICE AT A TIME \*\*\*
+
+\*\*\* WARNING: NEVER UPDATE THE DEVICE YOU USED TO BOOT \*\*\*
+
+>**WARNING:** Failure to follow this guidance may result in the soft *'bricking'* of your device. Recovery from a *'bricked'* state requires either: additional hardware like a JTAG programmer, OR returning the device to Mono to rebuild. To avoid a bad outcome - **follow these two rules!**
+
+---
+
+# 1. Overview
+
+Updating the firmware of your Mono Gateway Development Kit is ***not*** essential.
+
+However, updating your firmware provides the significant benefits of Mono's continued firmware development. This includes: useful helper tools, functionality, bug-fixes, polish, and suppresses the verbose `INFO` logging seen at boot on the shipped firmware. For highlights, see: [§1.1](#11-Major-firmware-changes) 
+
+The majority of the Mono firmware code is available and may be explored in the associated [meta-mono](https://github.com/we-are-mono/meta-mono/tree/master) repo, but excludes the (licensed NXP-proprietary) microcode injected at build-time. Final Mono firmware releases are available separately at [firmware.mono.si](https://firmware.mono.si/), see: [§2.4.4](#244-offline-update-requirements)
+
+## 1.1 Major firmware changes
+
+For the full detailed changelog, see: [we-are-mono/CHANGELOG.md](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md). 
+
+#### **Highlights include:**
+
+- Addition of the `firmware` update validator & helper - [2026-03-30](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-03-30--add-firmware-management-tool-and-calver-versioning)
+
+	- Detects boot medium - [2026-04-11](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-04-11--add-boot-medium-detection-and-simplify-firmware-update-tool)
+
+	- Adds --usb PATH & auto RO mount - [2026-04-18](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-04-18--add-usb-firmware-update-path)
+
+	- Adds --preserve-env option to retain U-boot env args - [2026-04-18](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-04-18--default-firmware-update-to-full-rewrite-add---preserve-env)
+
+	- Adds --url arg for local HTTP/TFTP firmware staging - [2026-06-12](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-04-18--add-usb-firmware-update-path)
+
+- Reversion of the cosmetic `udev` port remapping - [2026-03-28](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-03-28--remove-fman-ethernet-alias-ordering-patch-and-dt-aliases) - see also [HARDWARE.md](HARDWARE.md#3-network-port-layout)
+
+- Enables Power-off/halt via GPIO functionality - [2026-04-15](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-04-15--add-usb-storage-support-gpio-poweroff-and-fix-regressions)
+
+- Adds: [Firmware signing](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-03-30--add-optional-ecdsa-p-256-signing-for-firmware-images); [USB mass storage](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-04-15--add-usb-storage-support-gpio-poweroff-and-fix-regressions); [IPv6 DNS](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-06-13--security-review-follow-ups-supply-chain-pinning-cve-scanning); [vim-tiny + coloured PS1](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-06-13--recovery-ux-polish-colored-prompt-vim-tiny-firmware-tool-output)
+
+- Fixes: [Fix eMMC recovery](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-03-28--split-u-boot-environment-for-qspi-and-emmc-boot-media); [Fix LED](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-02-06--fix-package-name-collision-for-debapt-backends-5); [Fix FAT32 USB](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-04-18--add-usb-firmware-update-path); [Fix RTC](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-04-11--harden-firmware-security-fix-rtc-improve-build-quality)
+
+---
+
+# 2. Requirements
+
+**Before updating the firmware – read this chapter carefully.**
+
+This chapter covers what you will ***need***, and what you ***need to know*.**
+
+The ***next*** chapter provides a walk-through of the update process itself.
+
+## 2.1 Physical preparation
+
+All methods to perform firmware updates will require access to the small dip-switch on the main PCB. To access this, first remove the 4x T10 Torx screws and gently remove the clear plastic lid. For a visual guide see: [Mono's disassembly instructions](https://docs.mono.si/gateway-development-kit/hardware-description#disassembly-instructions)
+
+## 2.2 Firmware release files
+
+The firmware files available in each release from [firmware.mono.si](https://firmware.mono.si/) are listed below, along with their intended usage.
+
+>**NOTE:** Depending on how you intend to update your firmware (see: [§2.4](#24-firmware-update-requirements)), you may never interact with these files directly.
+
+```bash
+firmware-emmc-gateway-dk.bin		# 'eMMC' eSDHC firmware
+firmware-emmc-gateway-dk.bin.sig	# Sig used to validate 'eMMC' firmware
+firmware-qspi-gateway-dk.bin		# 'NOR' qspi flash firmware
+firmware-qspi-gateway-dk.bin.sig	# Sig used to validate 'NOR' firmware
+firmware-signing.pub				# Mono public signing key used in validation
+uboot-emmc-gateway-dk.env			# Default 'eMMC' U-Boot environment variables
+uboot-qspi-gateway-dk.env			# Default 'NOR' U-Boot environment variables
+```
+
+>**NOTE:** Firmware is now signed using the Mono ECDSA P-256 private key, and validated against the provided public key during the integrity-check of the `*.bin` firmware images.
+
+### 2.2.1 Firmware structure
+
+Firmware is not monolithic, and it is helpful to understanding both what is 'in' firmware, and how it is practically used. Taking the NOR firmware as an example, this has the below structure, where RO = Read-only, and RW = Read/write.
+
+| Block | Offset (MB) | Offset(hex) | Component                            | RO/RW |
+| ----- | ----------- | ----------- | ------------------------------------ | ----- |
+| mtd0  | 0           | 0x000000    | Reset codeword (RCW)+ BL2 bootloader | RO    |
+| mtd1  | 1           | 0x000000    | U-boot binary                        | RO    |
+| mtd2  | 3           | 0x000000    | U-boot-env - environment variables   | RW    |
+| mtd3  | 4           | 0x000000    | Fman microcode (v210.10.1)           | RO    |
+| mtd4  | 5           | 0x000000    | Device tree (Recovery)               | RO    |
+| mtd5  | 6           | 0x000000    | Backup/reserved                      | RO    |
+| mtd6  | 10          | 0x000000    | Kernel+initramfs (Recovery)          | RO    |
+
+**Succinctly:** 
+- mtd0-2: Configures, initialises and boots the hardware
+- mtd3: Unlocks the HW-offloading capabilities of the LS1046A SoC, see: [HW-OFFLOADING.md](HW-OFFLOADING.md)
+- mtd4-6: Provides the 'Recovery Linux' ramfs environment
+
+### 2.2.2 Board serial number
+
+Serial numbers for Mono Gateway Development Kits units of the form `MT-R01A-0326-0XXXX` where `XXXX` indicates position in the initial 1000 units.
+
+The serial number can be pulled from EEPROM using the following python snippet:
+
+```python
+sudo python3 - <<"EOF"
+import os, fcntl
+fd = os.open("/dev/i2c-3", os.O_RDWR)
+fcntl.ioctl(fd, 0x0706, 0x50)
+os.write(fd, bytes([0x00, 0x28]))
+print(os.read(fd, 64).split(b"\x00")[0].decode())
+EOF
+```
+
+Other methods for obtaining this info can be found in the official Mono docs, see: [getting started](https://docs.mono.si/gateway-development-kit/getting-started#reading-serial-number-and-mac-addresses-from-eeprom)
+
+## 2.3 (All methods) Common requirements
+
+**Have:**
+- 1x USB-C cable (for serial console)
+- 1x ethernet cable (to connect to an existing network / router / ISP gateway)
+- (If required) Backed-up U-boot environment variables, see - [§2.4.1](#241-u-boot-environment-variables)
+
+**Know:**
+- How to get into the 'Recovery Linux' environment, see: [§2.3.1](#231-recovery-linux-101) or [getting started](https://docs.mono.si/gateway-development-kit/getting-started#first-boot)).
+- How to use the serial console, see: [§2.3.2](#232-serial-console-101) or [getting started](https://docs.mono.si/gateway-development-kit/getting-started#first-boot)).
+- Which port/interface you plugged the ethernet cable into - see [HARDWARE.md](HARDWARE.md#31-as-shipped-with-cosmetic-correction-applied)
+- How the boot process works, see: [HARDWARE.md](HARDWARE.md#2-boot-chain)
+- The private IP range used by your local connected network (e.g. IPv4 192.168.0.0/24, or 10.0.0.0/24 etc)
+- The IP of your upstream router / modem (e.g. 192.168.0.1/24, or 10.0.0.1/24, etc)
+- Your DNS server IP (only if different to your existing router e.g. a PiHole or simila, see - [§2.3.3](#233-custom-dns-101))
+- How to debug network issues from the Linux CLI with `ip`, `ping` & `nslookup`
+
+### 2.3.1 'Recovery Linux' 101
+
+This is the small read-only linux environment that exists to enable firmware updates, and device recovery. It is part of the firmware image, as shown in [§2.2.1](#221-firmware-structure)
+
+**To access the 'Recovery Linux':**
+
+1) Power on
+2) Wait until prompted
+3) Press any key to interrupt boot
+4) Type `run recovery` + press `Enter` 
+5) Login as `root` (no password)
+
+### 2.3.2 Serial console 101
+
+On Windows, use [Putty](https://www.chiark.greenend.org.uk/~sgtatham/putty/latest.html): 
+Select connection type `serial`, speed `11520`, and serial line `COM1`. NB: If in doubt, check Windows Device Manager for the correct COM# port number.
+
+On Linux, open a terminal and use `tio`:
+```bash
+ls /dev/ttyUSB*				# Find the right ttyUSB device, usually /dev/ttyUSB0
+
+tio /dev/ttyUSB0			# Opens the required serial port 
+```
+
+### 2.3.3 Custom DNS 101
+
+If you have a custom DNS setup, e.g. using a PiHole at `192.168.1.254`, ensure you define this DNS server in `/etc/resolv.conf`. 
+
+Additional nameservers should follow the format of any existing default entries
+```bash
+cat /etc/resolv.conf	# Check the format used in your firmware version
+
+echo 'nameserver 192.168.1.254 pihole' >> /etc/resolv.conf		# Adds pihole DNS
+
+nslookup google.com		# Check DNS resolution works
+```
+
+## 2.4 Firmware update requirements
+
+There are four\* main methods to update the firmware of the Mono Gateway Development Kit:
+
+This section will cover pre-requisites and requirements for each method. 
+
+>**NOTE:** If performing the update for the first time you ***MUST*** use the 'Legacy' method. 
+
+1) ***'Legacy'*** – (1st time) Manual updating via standard Linux CLI tools - `ip`, `curl`, `dd`, `flashcp`, see: [§2.4.2](#242-legacy-update-requirements)
+
+2) ***'Normal'*** – (Recommended) Using the new `firmware` helper, and the latest [firmware.mono.si](https://firmware.mono.si/)  firmware, see: [§2.4.3](#243-normal-update-requirements)
+
+3) ***'Offline'*** – (Advanced) Using the new `firmware` helper, with locally staged firmware - e.g. via USB, TFTP, local HTTP server, see: [§2.4.4](#244-offline-update-requirements)
+
+4) ***'Mono Imager'*** – See: [mono-imager](https://github.com/HAHermsen/mono-imager)
+
+>\***NOTE:** Semi-hosting via JTAG debugger provides a further option of last resort which is also used to enable the recovery of **'bricked'** (unbootable) devices. This is out of scope for this guide. If required, see other community resources: e.g. [moshevds/mono-gateway-uart-recovery](https://github.com/moshevds/mono-gateway-uart-recovery/tree/main) or seek help via the [Mono Discord](https://discord.com/invite/FGHJ3J5v5W). 
+
+### 2.4.1 U-Boot environment variables
+
+These are located within the firmware at the 3 MB offset (see [§2.2.1](#221-firmware-structure)), and direct what OS U-Boot boots into after the hardware is initialised and initial boot self-tests have completed.
+
+>**WARNING: If you have installed an OS (OPNsense, OpenWRT, VyOS) that you want to keep, ensure you have backed-up your U-boot environment variables before proceeding. By default, the firmware update process will reset these to default. This may leave you unable to boot into a previous installed OS**
+
+>NOTE: If you are updating firmware, AND intend to re-install your OS, OR install a new one, you do not need to save these variables.
+
+There are two methods to save/retain the U-boot environment variables:
+
+#### A)  Manually copy your current variables to a text editor 
+
+>**NOTE:** If updating firmware for the 1st time and/or using the 'legacy' method, this is your only option
+
+1) Power on
+2) Interrupt boot to drop into the U-boot prompt
+3) Enter `pri` + hit return
+4) Select and copy the output to a text editor
+5) Complete the firmware update process
+6) Return to U-boot prompt, type `setenv` + return
+7) Paste the variables form your text editor
+8) Save by typing `saveenv` + return
+
+#### B) Use the --preserve-env flag with the `firmware` helper using the 'Normal' method
+
+```bash
+firmware update --preserve-env			# Update firmware; retain U-Boot env vars
+```
+
+### 2.4.2 *'Legacy'* update requirements
+
+>**NOTE:** **If performing the update for the first time - this is your only manual option**
+
+The 'legacy' method requires some awareness of some common linux CLI tools, as outlined below:
+```bash
+ip link set up <device>									# Brings up link
+ip link set up eth1										# e.g. for eth1
+
+ip address add <ip address/CIDR> dev <device>			# Sets IP address
+ip address add 10.0.0.200/24 dev eth1					# e.g. IP for eth1
+
+ip route add default via <router IP> dev <device>		# Sets default route
+ip route add default via 10.0.0.1 dev eth1				# e.g. route via eth1
+
+ping 8.8.8.8											# Test ping internet
+nslookup google.com										# Tests DNS lookup
+
+curl -u <user>:<password> -O <file location>			# Downloads file as <user>
+dd if=<image file> of=<device> bs=4096 skip=1 seek=1	# Writes image to device
+```
+
+You may note the `dd` command passes several additional arguments. These can be understood more clearly when read alongside the firmware structure shown in §2.2.1. 
+
+```bash
+...bs=4096 							# Write in 4kB chunks
+...skip=1  							# Skip reading the first N input blocks
+...seek=1 							# Skip writing the first N output blocks
+```
+In short, the `dd` command skips reading and writing to the first offset position. This is because the *'Reset codeword (RCW)+ BL2 bootloader'* located at the mtd0 / 0MB offset remains unchanged between firmware versions. The usable RCW configuration is effectively fixed by the implemented PCB design.
+
+### 2.4.3 *'Normal'* Update requirements 
+
+>**NOTE:** **When available - this is the recommended option.**
+
+By default, Mono Gateway Development Kit firmware updates are performed using the `firmware` helper application. This downloads, authenticates and verifies the firmware files prior to applying the firmware update. 
+
+No further preparation required - Move onto [§3](#3-the-firmware-update-process) to update your firmware.
+
+### 2.4.4 *'Offline'* update requirements
+
+>**NOTE:** This is ***not*** recommended, especially for the initial *'as-shipped'* firmware due to known issues (resolved in later firmware releases) with mounting FAT32 USB devices.
+
+To prepare to perform an *'offline'* firmware update, you must: 
+
+#### A) Obtain the firmware release files 
+
+Mono firmware can be obtained from [firmware.mono.si](https://firmware.mono.si/), using username: `mono`, and utilising a MAC address of your device, in the form `xx:xx:xx:xx:xx:xx` as the password. 
+
+>**NOTE:** MAC addresses are noted on a physical sticker on the base of the unit, or can be found via use of the `ip address show` command within the 'Recovery Linux' environment.
+
+#### B) Stage firmware files in an accessible location
+
+>**NOTE:** On the 'as-shipped' shipped firmware, known bugs will frustrate the use of USB drives. 
+
+**USB drive:**
+Move the firmware files onto a FAT32 formatted USB stick, either in the drive root or 'firmware/' folder. Insert the prepared USB drive into the middle USB-C slot on the Mono Gateway Development kit. For a visual reference, see: [Mono's Port Description](https://docs.mono.si/gateway-development-kit/hardware-description#port-description)
+
+>**NOTE:** The USB data port is USB-C. A USB-A to USB-C adaptor may be required.
+
+**Locally hosted web-server:**
+Firmware can also staged on a local web server, and retrieved via the same `curl` approach used in the 'Legacy' method. Make note of the URL for the staging location.
+
+With the firmware staged, move onto [§3](#3-the-firmware-update-process) to update your firmware.
+
+---
+
+# 3. The firmware update process
+
+\*\*\* WARNING: ONLY UPDATE THE FIRMWARE ON ONE STORAGE DEVICE AT A TIME \*\*\*
+
+\*\*\* WARNING: NEVER UPDATE THE DEVICE YOU USED TO BOOT \*\*\*
+
+>**WARNING:** Failure to follow this guidance may result in the soft *'bricking'* of your device. Recovery from a *'bricked'* state requires either: additional hardware like a JTAG programmer, OR returning the device to Mono to rebuild. To avoid a bad outcome - **follow these two rules!
+
+### Update methods
+
+>**NOTE:** If performing the update for the first time you ***MUST*** use the 'Legacy' method. 
+
+- Using `Mono-imager`, see: [§3.1](#31-using-mono-imager)
+
+- ***'Legacy'*** method, see: [§3.2](#32-legacy-method)
+
+- ***'Normal'*** method, see: [§3.3](#33-normal-method-using-firmware-helper)
+
+- ***'Offline'*** method, see: [§3.4](#34-offline-method)
+
+## 3.1 Using `Mono-imager`
+
+This is the newest of the firmware update methods and aims to provide a streamlined and guided firmware update and OS installation process. **This should be your first choice in Firmware update methods**
+
+Full documentation for using `mono-imager` can be found in the [mono-imager](https://github.com/HAHermsen/mono-imager) GitHub repo.
+
+## 3.2 'Legacy' method
+
+>**NOTE:** If performing the update for the first time you ***MUST*** use start here
+
+**Before you start: - READ: [§2 Requirements](#2-requirements)**
+
+Ensure you have all the information you will need to complete this process.
+
+### START
+
+>**STEP #1** Set the dip-switch on the PCB to 'NOR'
+>**NOTE: (This is the default position) You are booting from NOR**
+
+---
+
+>**STEP #2** Power-on your device
+
+---
+
+>**STEP #3** When prompted, interrupt boot
+
+---
+
+>**STEP #4** Type `run recovery` + hit return
+
+---
+
+>**STEP #5** login as user `root` (no password)
+
+---
+
+>**STEP #6** Connect a network cable from your existing router to the Mono Gateway
+
+---
+
+>**STEP #7** Using the commands outlined in [§2.4.2](#242-legacy-update-requirements) enable the interface you have used to connect the Mono Gateway development kit, define an IP address, and default route.
+
+```bash
+# EXAMPLE: To config up eth1, with an IP of 10.0.0.200 with the 10.0.0.0/24 network, with your (existing router) at 10.0.0.1:
+
+ip link set up eth1										# set eth1 admin up
+ip address add 10.0.0.200/24 dev eth1					# add IP for eth1
+ip route add default via 10.0.0.1 dev eth1				# add route via eth1
+
+```
+
+---
+
+>**STEP #8** Test your connection:
+
+```bash
+ping 8.8.8.8											# Test ping internet
+nslookup google.com										# Tests DNS lookup
+```
+---
+
+>**STEP #9** Download firmware for eMMC, replacing `XX:XX:XX:XX:XX:XX` with your MAC (see sticker on base)
+```bash
+curl -ku mono:XX:XX:XX:XX:XX:XX -O https://firmware.mono.si/firmware-emmc-gateway-dk.bin 
+```
+
+---
+
+>**STEP #10** Flash the eMMC firmware
+
+>\*\* **WARNING: If you have installed an OS (OPNsense, OpenWRT, VyOS) that you want to keep, ensure you have backed-up your U-boot environment variables before proceeding. The next operation will reset these, and may render your existing OS unbootable** \*\*
+
+```bash
+dd if=firmware-emmc-gateway-dk.bin of=/dev/mmcblk0 bs=4096 skip=1 seek=1 
+```
+
+---
+
+>**STEP #11** Flip the dip-switch on the PCB to 'eMMC'
+>**NOTE: You will now boot from eMMC**
+
+---
+
+>**STEP #12** Reboot (from eMMC)
+
+```bash
+reboot
+```
+
+---
+
+>**STEP #13** Test eMMC boot works
+
+If it boots - eMMC flashed successfully, and you are 50% done. If you get no output, go back to STEP #1 and retry.
+
+---
+
+>**STEP #14** (now) Repeat steps #3 to #8 to setup your IP, test your connection and prepare to update the NOR flash.
+>**NOTE:** You may note that the 'Recovery Linux' prompt looks different - this is expected
+
+---
+
+>**STEP #15** You can now use the new `firmware` helper to flash NOR
+
+>\*\* **WARNING: If you have installed an OS (OPNsense, OpenWRT, VyOS) that you want to keep, ensure you have backed-up your U-boot environment variables before proceeding. The next operation will reset these, and may render your existing OS unbootable** \*\*
+
+```bash
+firmware update					# Update firmware; restore default U-Boot env vars
+
+firmware update --preserve-env	# Update firmware; preserve U-Boot env vars
+
+# Follow the prompts, and wait for the process to complete.
+``````
+
+\*\*\* DO NOT INTERRUPT THE PROCESS ONCE STARTED \*\*\*
+
+---
+
+>**STEP #16** Flip the dip-switch on the PCB back to 'NOR'
+>**NOTE: You will now boot from NOR**
+
+---
+
+>**STEP #17** Reboot (from NOR)
+```bash
+reboot
+```
+
+---
+
+>**STEP #18** Test NOR boot works
+
+If it boots, then NOR flashed successfully. **You are 100% done.** 
+If you get no output, go back to step STEP #11 and retry.
+
+---
+### FINISH!
+
+---
+
+## 3.3 'Normal' method (using `firmware` helper)
+
+**Before you start: - READ: [§2 Requirements](#2-requirements)**
+
+Ensure you have all the information you will need to complete the process.
+
+### START
+
+>**STEP #1** Set the dip-switch on the PCB to 'NOR'
+>**NOTE: (This is the default position) You are booting from NOR**
+
+---
+
+>**STEP #2** Power-on your device
+
+---
+
+>**STEP #3** When prompted, interrupt boot
+
+---
+
+>**STEP #4** Type `run recovery` + hit return
+
+---
+
+>**STEP #5** login as user `root` (no password)
+
+---
+
+>**STEP #6** Connect a network cable from your existing router to the Mono Gateway
+
+---
+
+>**STEP #7** Using the commands outlined in 2.3.2 enable the interface you have used to connect the Mono Gateway development kit, define an IP address, and default route.
+
+```bash
+# EXAMPLE: To config up eth1, with an IP of 10.0.0.200 with the 10.0.0.0/24 network, with your (existing router) at 10.0.0.1:
+
+ip link set up eth1										# set eth1 admin up
+ip address add 10.0.0.200/24 dev eth1					# add IP for eth1
+ip route add default via 10.0.0.1 dev eth1				# add route via eth1
+```
+
+---
+
+>**STEP #8** Test your connection:
+
+```bash
+ping 8.8.8.8											# Test ping internet
+nslookup google.com										# Tests DNS lookup
+```
+---
+
+>**STEP #9** Use the `firmware` helper to flash eMMC
+
+\*\* **WARNING: If you have installed an OS (OPNsense, OpenWRT, VyOS) that you want to keep, ensure you have backed-up your U-boot environment variables before proceeding. The next operation will reset these, and may render your existing OS unbootable** \*\*
+
+```bash
+firmware update					# Update firmware; restore default U-Boot env vars
+
+firmware update --preserve-env	# Update firmware; preserve U-Boot env vars
+
+# Follow the prompts, and wait for the process to complete.
+```
+
+
+---
+
+>**STEP #10** Flip the dip-switch on the PCB to 'eMMC'
+>**NOTE: You will now boot from eMMC**
+
+---
+
+>**STEP #11** Reboot (from eMMC)
+
+```bash
+reboot
+```
+
+---
+
+>**STEP #12** Test eMMC boot works
+
+If it boots - eMMC flashed successfully, and you are 50% done. If you get no output, go back to STEP #1 and retry.
+
+---
+
+>**STEP #13** (now) Repeat steps #3 to #8 to setup your IP, test your connection and prepare to update the NOR flash.
+>**NOTE:** You may note that the 'Recovery Linux' prompt looks different - this is expected
+
+---
+
+>**STEP #14** You can now use the new `firmware` helper to flash NOR
+
+```bash
+firmware update					# Update firmware; restore default U-Boot env vars
+
+firmware update --preserve-env	# Update firmware; preserve U-Boot env vars
+
+# Follow the prompts, and wait for the process to complete.
+```
+
+\*\*\* DO NOT INTERRUPT THE PROCESS ONCE STARTED \*\*\*
+
+---
+
+>**STEP #15** Flip the dip-switch on the PCB back to 'NOR'
+>**NOTE: You will now boot from NOR**
+
+---
+
+>**STEP #16** Reboot (from NOR)
+```bash
+reboot
+```
+
+---
+
+>**STEP #17** Test NOR boot works
+
+If it boots, then NOR flashed successfully. **You are 100% done.** 
+If you get no output, go back to step STEP #11 and retry.
+
+---
+### FINISH!
+
+---
+
+## 3.4 'Offline' method
+
+**Before you start: - READ: §2!** 
+
+Ensure you have all the information you will need to complete the process.
+
+This is a variation of the process shown in [§3.3](#33-normal-method-using-firmware-helper) with a singular modification in steps #9 + #14 which directs the `firmware` helper where to source the firmware `*.bin` files. 
+
+>**NOTE:** For the full range of available options, run `firmware help`
+
+```bash
+# For firmware located on a FAT32 USB drive in / or /firmware/ use:
+firmware update --usb
+
+# For firmware located on a local webserver at URL use:
+firmware update --url URL
+
+# For firmware located locally at PATH [e.g. previously obtained via curl] use:
+firmware update --from PATH
+```
+
+
+
+## 3.5 Troubleshooting
+
+Some basic troubleshooting tips.
+
+### 3.5.1 If ping fails
+
+1) Check your network cable is actually in eth1... 
+
+```bash
+ip a show						# prints interface IPs, MACs, link state
+```
+
+If your configured interface, e.g. `eth1` shows `no-carrier` - you've have likely configured another interface by mistake, and not the one with the network cable. For why this may happen, see: [HARDWARE.md](HARDWARE.md#31-as-shipped-with-cosmetic-correction-applied). Fix by moving the cable to the correct interface, at which point the `no-carrier` next to your configured interface will no longer be observed in the output of `ip a show`.
+
+2) Check any upstream firewall is not blocking/dropping traffic - if so, configure it accordingly.
+
+### 3.5.2 If nslookup fails:
+
+1) Ensure you have a working, accessible DNS server defined in `/etc/resolv.conf` and retry. For how to modify the local DNS configuration, see: [§2.3.3](FIRMWARE.md#233-custom-dns-101)
+
+2) Check any upstream firewall is not blocking/dropping traffic - if so, configure it accordingly.

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -1,0 +1,285 @@
+# Hardware Overview: Mono Gateway Development Kit
+
+The primary source of truth for the physical hardware is the [Mono development kit - hardware description](https://docs.mono.si/gateway-development-kit/hardware-description). This documentation builds on this foundation, and addresses the quirks.
+
+# 1. Specification
+
+|                                |                                                                                                                                                                                                                                                   |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **CPU**                        | NXP QorIQ LS1046A SoC: 4x Cortex-A72 @1.6 GHz                                                                                                                                                                                                     |
+| **RAM**                        | 8 GB ECC DDR4 @2100 MT/s                                                                                                                                                                                                                          |
+| **Networking**                 | 2x SFP+ 10 Gbps (10GBASE-R)<br>3x RJ45 1 Gbps (1000BASE-T)                                                                                                                                                                                        |
+| **M.2 expansion\***            | 1x M.2_1 Key-E (Left) *'Smart home'* – interfaces: SDIO, UART, SPI, I2C – Usage: low-bandwidth tri-radio cards (Wifi5, Bluetooth, Thread)<br>1x M.2_2 Key-E (Right) *'Wireless'* – interfaces: UART, PCIe 3.0 x1 – Usage: Wifi6 2x2 MU-MIMO cards |
+| **Storage**                    | *User selectable boot source via PCB dip-switch:*<br>1x 64 MB NOR flash for Bootloader<br>1x 32 GB eMMC for Operating System                                                                                                                      |
+| **Firmware**                   | NOR + eMMC (user-updatable) firmware targets are available, see: [FIRMWARE.md](FIRMWARE.md#244-offline-update-requirements)                                                                                                                       |
+| **Boot loader**                | U-Boot via `booti`                                                                                                                                                                                                                                |
+| **External I/O**               | 1x USB-C 3.1 5 Gbps port, max 5V 3A<br>1x USB-C UART (serial) Console, 115200 baud (`ttyS0`)                                                                                                                                                      |
+| **Internal I/O**               | 1x 4-pin 5V PWM CPU fan<br>1x 4-pin 5V header (unused)<br>1x Programmable RGBW status LED<br>1x JTAG programmer connector<br>100+ PCB test points                                                                                                 |
+| **Power supply<br>(external)** | 1x USB-C PD 3.0: 20V 2A (40W), or 15V 3A (45W)                                                                                                                                                                                                    |
+> **NOTE:** As a development kit, additional features are included to enable: 
+> OS installation, device recovery, firmware updates, and HW debugging of both the SoC and PCB
+
+>**\*WARNING:** The two m.2 E-key slots have different presented interfaces and pinouts. Compatibility with user-supplied m.2 E-key hardware is not guaranteed, and incorrect use may result in hardware damage. Check the datasheet for your intended m.2 E-key device to establish interface requirements and pin-compatibility. For a list of the tested m.2 devices, and full socket pin-assignments see - [Mono hardware description](https://docs.mono.si/gateway-development-kit/hardware-description#supported-cards)
+
+The Mono Gateway Development Kit is an extremely versatile device, and its design enables user-recovery in an abnormally wide range of scenarios. Even if rendered *'bricked'* and unbootable, the device still may be recovered via a (separate) JTAG hardware debugger probe ([e.g. TC2050](https://www.tag-connect.com/product/tc2050-idc-050-all)).
+
+---
+# 2. Boot chain
+
+In order to use this device effectively, some foundational knowledge of how it operates is required, starting with how it effects the initial boot process. 
+
+There is no fixed 'BIOS' ROM as you might find on an x86 computer, as this is an embedded device. The user can however control the boot source (via a physical dip-switch on the PCB), and after initialisation of the hardware via the U-Boot bootloader, what boots next in the chain.
+
+>**NOTE:** Use **NOR** as your default boot device, **except when updating the NOR [FIRMWARE.md](FIRMWARE.md)**. This ensures that after installing an OS to the eMMC, your device remains bootable.
+
+## 2.1 Boot chain: As shipped + OpenWRT + OPNsense
+
+Initially, either the 64 MB NOR flash, OR the 32 GB eMMC can be used as the primary boot device, as shown below. This works because each storage device has a it's own separate copy of U-Boot, and a small *'Recovery Linux'* environment in an initial firmware partition located in the first 32MB of each device. The primary use of the *'Recovery Linux'* environment is to perform firmware upgrades, and to enable device recovery. [FIRMWARE.md](FIRMWARE.md) provides a brief *'how-to'* guide for updating the device firmware, and provides critical warnings for avoid common issues.
+
+**The *active* boot device is controlled via a physical dip-switch on the main PCB.** This defines which storage device is used to load U-boot when the system is powered. 
+
+```mermaid
+flowchart LR
+  A((Power On)) --> B{dip-switch}
+  B -->|NOR boot| C{U-BOOT}
+  B -->|eMMC boot| D{U-BOOT}
+  C -.->|interrupt| E(U-Boot shell)
+  C -.->|"❌ OOM"| EFI("GRUB/EFI")
+  E -.->|'run recovery'| FWNOR
+  E -.->|USB boot| K("Live-boot")
+  D -.->|interrupt| F(U-Boot shell)
+  F-.->|'run recovery'| FWEMMC
+  C -->|Normal boot| P3(eMMC p3)
+  D -->|Normal boot| P3(eMMC p3)
+    
+  subgraph EMMC ["eMMC (/dev/mmcblk0)"]
+    direction LR
+    FWEMMC("Firmware + Recovery Linux")
+    P1("p1: boot")
+    P2("p2: EFI")
+    P3("p3: OpenWRT")
+  end
+  
+  subgraph NOR ["NOR (/dev/mtd0)"]
+    direction LR
+    FWNOR("Firmware + Recovery Linux")
+  end
+    
+  style A fill:#222,stroke:#333,color:#fff
+  style B fill:#640,stroke:#333,color:#fff
+  style EFI fill:#a44,stroke:#333,color:#fff
+  style C fill:#48a,stroke:#333,color:#fff
+  style D fill:#48a,stroke:#333,color:#fff
+  style E fill:#48c,stroke:#333,color:#fff
+  style F fill:#48c,stroke:#333,color:#fff
+  style P1 fill:#340,stroke:#333,color:#aaa
+  style P2 fill:#666,stroke:#333,color:#aaa
+  style P3 fill:#4a7,stroke:#333,color:#fff
+  style K fill:#4a9,stroke:#333,color:#fff
+  style FWNOR fill:#963,stroke:#333,color:#fff
+  style FWEMMC fill:#963,stroke:#333,color:#fff
+  style EMMC fill:#ccc,stroke:#333,color:#111
+  style NOR fill:#ccc,stroke:#333,color:#111
+```
+
+>**NOTE** The EFI/GRUB path is permanently broken. DPAA1 (see: [HW-OFFLOADING.md](HW-OFFLOADING.md)) reserved-memory nodes in the device tree cause GRUB to hit an out-of-memory (OOM) error during `bootefi`. Nobody plans to fix it. `booti` works, costs nothing, and skips GRUB entirely. Sometimes the universe does you a favour. 
+
+## 2.2 Boot chain: for VyOS
+
+After installing Vyos there are three notable changes to the boot chain, at present:
+1. Booting from eMMC will fail. You must boot from **NOR**. NOR is now also the only route to access 'Recovery linux', if it is required.
+2. If a VyOS USB is inserted, U-boot will boot from USB (live mode) **before** attempting to boot VyOS images installed on eMMC
+3. Reading from `/boot/vyos.env` from eMMC p3 (`mmc 0:3`) → defines which named VyOS image is then booted.
+
+```mermaid
+flowchart LR
+  A((Power On)) --> B{dip-switch}
+  B -->|NOR boot| C{U-BOOT}
+  B -.->|"❌ eMMC boot"| D(U-BOOT)
+  C -.->|interrupt| E(U-Boot shell)
+  E -.->|'run recovery'| FWNOR
+  C -.->|USB boot| K("Live-boot")
+  C -->|Normal boot| P3(eMMC p3)
+  subgraph EMMC ["eMMC (/dev/mmcblk0)"]
+    direction LR
+    P3("p3: VYOS")
+    FW("Reserved")
+    P1("p1: boot")
+    P2("p2: EFI")
+  end
+  
+  subgraph NOR ["NOR (/dev/mtd0)"]
+    direction LR
+    FWNOR("Firmware + Recovery Linux")
+  end
+  
+  style A fill:#222,stroke:#333,color:#fff
+  style B fill:#640,stroke:#333,color:#fff
+  style C fill:#48a,stroke:#333,color:#fff
+  style D fill:#a44,stroke:#333,color:#fff
+  style E fill:#48c,stroke:#333,color:#fff
+  style P1 fill:#340,stroke:#333,color:#aaa
+  style P2 fill:#666,stroke:#333,color:#aaa
+  style P3 fill:#4a7,stroke:#333,color:#fff
+  style K fill:#4a9,stroke:#333,color:#fff
+  style FWNOR fill:#963,stroke:#333,color:#fff
+  style EMMC fill:#ccc,stroke:#333,color:#111
+  style NOR fill:#ccc,stroke:#333,color:#111
+  style FW fill:#666,stroke:#333,color:#aaa
+```
+
+>**NOTE:** If installing VyOS onto the eMMC per [INSTALL.md](INSTALL.md) you will (currently) lose the ability to directly boot from eMMC. This is a known [issue#24](https://github.com/mihakralj/vyos-ls1046a-build/issues/24) for which a fix is known, but not yet deployed. This can be remedied via re-imaging the eMMC firmware located in the first 32 MB *'reserved'* partition on the eMMC. To do so manually, see [FIRMWARE.md](FIRMWARE.md).
+
+## 2.2.1 Diving deeper
+
+For the curious, a full annotated boot sequence from earlier development can be walked-through in [plans/BOOT-PROCESS.md](plans/BOOT-PROCESS.md). This notes a number of boot log messages that have since been investigated, and are now suppressed in subsequent releases. These relate to typical x86 capabilities that simply are not present on this aarch64 HW, e.g. [IOMMU](https://en.wikipedia.org/wiki/Input%E2%80%93output_memory_management_unit) nodes.
+
+---
+# 3. Network Port Layout
+
+The port layout on the Mono Gateway can be very confusing due to a hardware quirk that breaks the expected mapping between physical ports, and their logical named order. 
+
+The initial (as shipped) Mono Gateway Development Kit firmware applies a cosmetic fix for this (using a `udev` rule at boot-time). However, as [§3.1.1](HARDWARE.md#311-reversion) notes, all subsequent firmware releases ([2026-03-28+](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-03-28--remove-fman-ethernet-alias-ordering-patch-and-dt-aliases)) now revert this for consistency between installed *'Recovery Linux'* environments and the main (eMMC installed) OS, e.g. VyOS.
+
+**Root cause** - The hardware network devices are enumerated out of step with their physical presentation, as 1,2,0,3,4, whereas one might more routinely expect 0,1,2,3,4. This is an entirely cosmetic issue, but it remains a source of persistent confusion amongst new users updating from the initial stock firmware.
+
+## 3.1 As shipped, with cosmetic correction applied
+
+```mermaid
+block-beta
+  columns 7
+  block:rj45:3
+    columns 3
+    eth0["eth0\nRJ45\nSGMII"]
+    eth1["eth1\nRJ45\nSGMII"]
+    eth2["eth2\nRJ45\nSGMII"]
+  end
+  space
+  block:sfp:3
+    columns 3
+    eth3["eth3\nSFP+\n10GBase-R"]
+    eth4["eth4\nSFP+\n10GBase-R"]
+  end
+
+  style eth0 fill:#4a7,stroke:#333,color:#fff
+  style eth1 fill:#4a7,stroke:#333,color:#fff
+  style eth2 fill:#4a7,stroke:#333,color:#fff
+  style eth3 fill:#49a,stroke:#333,color:#fff
+  style eth4 fill:#49a,stroke:#333,color:#fff
+```
+Whilst readable, the correction will break for any subsequently loaded OS (VyOS, OPNsense, etc) unless they too manually apply further corrective remapping. It also breaks the expected logical sequencing of the physical MAC address assigned to the interfaces, which remain out-of-order.
+
+### 3.1.1 Reversion
+
+Requiring maintaining a manual patch that all OS maintainers must apply manually was not seen as a consistent or supportable approach. Following a discord straw-poll, Mono elected to revert the cosmetic fix from [Mono firmware 2026-03-28](https://github.com/we-are-mono/meta-mono/blob/master/CHANGELOG.md#2026-03-28--remove-fman-ethernet-alias-ordering-patch-and-dt-aliases) onwards. This provide a more consistent and supportable experience and reverts the (at-boot) port mapping to that shown in §3.2 below.
+
+> **NOTE:** All units, as shipped, have the cosmetic correction applied, and the interface order within the firmware *'Recovery Linux'* environment reflects this correction. This may see the same physical interface assigned during the first firmware update, change it's assigned name after the firmware update. This is expected behaviour, but can be confusing if unexpected.
+
+## 3.2 The hardware order, as enumerated – 1,2,0,3,4 
+```mermaid
+flowchart TB
+  subgraph LDEV ["logical devices"]
+    direction LR
+    L1["eth1\n1G"]
+    L2["eth2\n1G"]
+    L0["eth0\n1G"]
+    L3["eth3\n10G"]
+    L4["eth4\n10G"]
+  end
+
+  subgraph PDEV ["Physical presentation"]
+    direction LR
+    G0["Left\nRJ45"] & G1["Centre\nRJ45"] & G2["Right\nRJ45"]
+    S1["Left\nSFP+"] & S2["Right\nSFP+"]
+  end
+
+  L1 --- G0
+  L2 --- G1
+  L0 --- G2
+  L3 --- S1
+  L4 --- S2
+
+  style LDEV fill:#48a,stroke:#333,color:#fff
+  style PDEV fill:#963,stroke:#333,color:#fff
+  style L1 fill:#640,stroke:#333,color:#fff
+  style L2 fill:#640,stroke:#333,color:#fff
+  style L0 fill:#640,stroke:#333,color:#fff
+  style L3 fill:#668,stroke:#333,color:#fff
+  style L4 fill:#668,stroke:#333,color:#fff  
+  style G0 fill:#4a7,stroke:#333,color:#fff
+  style G1 fill:#4a7,stroke:#333,color:#fff
+  style G2 fill:#4a7,stroke:#333,color:#fff
+  style S1 fill:#49a,stroke:#333,color:#fff
+  style S2 fill:#49a,stroke:#333,color:#fff
+```
+
+This quirk does divide opinions, but it remains a more consist default. It can be readily addressed once, post-boot, in your OS of choice, as show in [§3.3](HARDWARE.md#33-vyos-port-naming) below. 
+
+> **NOTE:** This disparity is most likely to be observed in the firmware 'Recovery Linux' environment, e.g. when applying any subsequent firmware updates from the as-shipped FW release, or when migrating from one eMMC installed OS to another.
+
+## 3.3 VyOS port naming
+
+Enumeration proceeds normally, but sanity is restored.
+
+Interface names are inherently fungible, and VyOS elects to rename/renumber the physical ports to restore the more intuitive ordering scheme. This provides a more sustainable route, to the same desired outcome.
+
+```mermaid
+block-beta
+  columns 7
+  block:rj45:3
+    columns 3
+    eth0["eth0\nRJ45\nSGMII"]
+    eth1["eth1\nRJ45\nSGMII"]
+    eth2["eth2\nRJ45\nSGMII"]
+  end
+  space
+  block:sfp:3
+    columns 3
+    eth3["eth3\nSFP+\n10GBase-R"]
+    eth4["eth4\nSFP+\n10GBase-R"]
+  end
+
+  style eth0 fill:#4a7,stroke:#333,color:#fff
+  style eth1 fill:#4a7,stroke:#333,color:#fff
+  style eth2 fill:#4a7,stroke:#333,color:#fff
+  style eth3 fill:#49a,stroke:#333,color:#fff
+  style eth4 fill:#49a,stroke:#333,color:#fff
+```
+The only notable anomaly this unavoidably introduces is seen in the order in which interfaces are printed via commands like `ip address show`. This is an extremely small price to pay for regaining certainty in of which interface you have just plugged your cable into.
+
+>**NOTE:** As this renaming occurs *within VyOS*, the interface numbering seen in the separate firmware 'Recovery Linux' environment continues to reflect the hardware ordering shown in [§3.2](HARDWARE.md#32-the-hardware-order-as-enumerated---12034) above. Be mindful of this, especially if you regularly update the firmware and rely on muscle-memory for interface names!
+
+---
+
+# 4. Hardware design details - TBC
+
+In addition to the headline specification outlined in §1, many further HW design details have been discovered, which may provide a useful reference. in during troubleshooting, understanding the device operations, and the practical limitations of this excellent hardware.
+
+**Includes:**
+- Component IC details and spec sheets (where available)
+- Enumeration of the I2C buses, SPI, UARTs, GPIO and associated MUXs
+- Design-time configurational choices for the LS1046A SoC
+- Known limitations
+- SPF+ module compatibility list
+
+## 4.1 Additional hardware specifications
+
+### 4.1.1 Identified IC components
+\<IC part numbers, HW address etc\>
+### 4.1.2 Enumerated communication buses
+\<Map I2C buses and devices here\>
+## 4.2 LS1046A SoC configuration
+
+### 4.2.1 Overview: CPU-Device Signalling requirements
+\<CPU-device signalling 101\>
+### 4.2.2 Role of the Reset Code Word (RCW)
+\<Purpose, impact on SoC I/O\>
+
+### 4.2.3 SERDES configuration in Mono Gateway Development Kit
+\<Map SerDes lanes to devices/functions\>
+
+## 4.3 Known limitations + workarounds
+\<1/10G SFP retimer clock; No HG SGMII etc\>
+
+## 4.4 SFP+ module compatibility list
+\<Best efforts collation of all user-testing\>

--- a/HW-OFFLOADING.md
+++ b/HW-OFFLOADING.md
@@ -1,0 +1,167 @@
+# HW-Offloading on the NXP LS1046A SoC
+### TL;DR: A DPAA1 driver and ASK are both required for HW-offloading in the LS1064A SoC. Different versions exist with different functionality. Both are being rebuilt for use with VyOS on Kernel 6.18
+
+Achieving wire-speed throughput on the Mono Gateway Development Kit requires utilising the HW-offloading capabilities of the LS1046A SoC, specifically it's I/O ASIC. Here we provide an overview of what this is, how it works, and why rebuilding parts of the SW machinery as 'ASK2' for use modern Kernels (6.18+), as used in VyOS 'Rolling', is now essential.
+
+If you want a deep-dive on this topic - see [arch/README.md](arch/README.md)
+
+For an accessible higher-level overview - continue below.
+
+---
+# 1. DPAA1/ASK Network Architecture Overview
+
+To understand HW-offload on the LS1046A SoC you first need to understand the DPAA1 architecture, and how the various parts of it work together. These parts include the DPAA1 kernel driver, the NXP microcode the ASIC itself loads, and how ASK programmes these functions collectively to enable HW-offloading.
+
+Lots of acronyms. Lets unpack.
+
+- ASIC = [Application Silicon Integrated Circuit](https://en.wikipedia.org/wiki/Application-specific_integrated_circuit) — Built to do specific things, really well
+- DPAA = Data Path Acceleration Architecture — Defines the ASIC accelerator functions
+- ASK = Application Solutions Kit — Defines how the ASIC functions interoperate
+- Microcode — In this specific context, defines which ASIC functions are enabled
+
+This is a big topic, best approached by first visualising the outcome, as below.
+
+```mermaid
+flowchart TB
+  subgraph CORES ["4× Cortex-A72 Cores"]
+    C0("Core 0") & C1("Core 1") & C2("Core 2") & C3("Core 3")
+  end
+
+  subgraph PORTALS ["HW Portals (1 per core)"]
+    BP("BMan") & QP("QMan")
+  end
+
+  subgraph FMAN ["FMan"]
+    direction LR
+    M0("MEMAC 4\neth0 SGMII")
+    M1("MEMAC 5\neth1 SGMII")
+    M2("MEMAC 1\neth2 SGMII")
+    M3("MEMAC 9\neth3 10G")
+    M4("MEMAC 10\neth4 10G")
+  end
+
+  subgraph PHY ["PHY Layer"]
+    direction LR
+    G0("GPY115C\nMDIO :00") & G1("GPY115C\nMDIO :01") & G2("GPY115C\nMDIO :02") & S1("SFP+\nfixed-link") & S2("SFP+\nfixed-link")
+  end
+
+  subgraph ASIC ["I/O ASIC"]
+    PORTALS <-->|"DMA"| FMAN
+  end
+
+  M0 --- G0
+  M1 --- G1
+  M2 --- G2
+  M3 --- S1
+  M4 --- S2
+  CORES <-->|"dequeue/enqueue"| PORTALS
+  
+  style FMAN fill:#4a7,stroke:#333,color:#fff
+  style M0 fill:#640,stroke:#333,color:#fff
+  style M1 fill:#640,stroke:#333,color:#fff
+  style M2 fill:#640,stroke:#333,color:#fff
+  style M3 fill:#640,stroke:#333,color:#fff
+  style M4 fill:#640,stroke:#333,color:#fff
+  style PORTALS fill:#4a7,stroke:#333,color:#fff
+  style BP fill:#668,stroke:#333,color:#fff
+  style QP fill:#668,stroke:#333,color:#fff 
+  style PHY fill:#963,stroke:#333,color:#fff
+  style G0 fill:#48a,stroke:#333,color:#fff
+  style G1 fill:#48a,stroke:#333,color:#fff
+  style G2 fill:#48a,stroke:#333,color:#fff
+  style S1 fill:#48a,stroke:#333,color:#fff
+  style S2 fill:#48a,stroke:#333,color:#fff
+  style CORES fill:#aaa,stroke:#333,color:#111
+  style C0 fill:#963,stroke:#333,color:#fff
+  style C1 fill:#963,stroke:#333,color:#fff
+  style C2 fill:#963,stroke:#333,color:#fff
+  style C3 fill:#963,stroke:#333,color:#fff
+  style ASIC fill:#aaa,stroke:#333,color:#111
+```
+A visual overview of DPAA1 of the LS1064A SoC in the Mono Gateway development kit. 
+
+>**NOTE:** The I/O ASIC sits between the Physical network port PHYs (bottom) and the CPU (top). If the HW-offloading does it's job well, packets enter and leave the device without ever needing to touch the CPU. That is what HW-Offloading means. It leaves the CPU 'free' to do other work.
+
+One diagram in and more Acronyms to expand.
+
+- FMan = Frame manager — inspects, splits, enqueues on ingress/egress
+- QMan = Queue manager — controls input/output queues and scheduling for other functions
+- BMan = Buffer manager — controls frame/data buffers in memory for other functions
+- CAAM (not shown) = Cryptographic Accelerator and Assurance Module — performs accelerated crypto functions
+
+The curious can find more detail in existing public NXP documentation on [QorIQ DPAA1](https://docs.nxp.com/bundle/GUID-39A0A446-70E5-4ED7-A580-E7508B61A5F1/page/GUID-194DD21B-FC7F-4AF4-BB44-86F4B4A402D2.html) and [Layerscape DPAA/DPAA1](https://docs.nxp.com/bundle/LLDPUG_L6.1.36_2.1.0/page/topics/introduction_003.html) two names, same thing. The name change was to differentiate from the (unrelated) DPAA2 architecture that launched later.
+
+''DPAA1' as a term is more commonly used to refer to the kernel DPAA1 driver for the SoC architecture of the same name. There are parallels between this DPAA1 driver and those of a simple network device, along with the added complexity associated with driving an entire I/O ASIC.
+
+## 1.1 A (brief) history of ~~time~~ relevant DPAA1 driver versions
+
+- **NXP lf-5.4 LSDK** — End of active NXP ASK development. This uses the original NXP source for their hard-detached fork of kernel 5.4 branch. From a time when coding discipline was... _Different._ 
+- **NXP lf-6.12.49** — **(what Mono shipped)** — A forward-port to another hard-detached NXP fork of the 6.12.y kernel branch that also stubs older 5.4 patches. Mono ships a version of this made with `Claude`.
+- **OPNsense 26.1** — A re-port of the full lf-5.4 SDK + ASK 1.x user-space to FreeBSD, using a Linux shim.
+- **NXP lf-6.6.y** — Forward-port that also stubbed older 5.4 patches, used in an initial Vyos build
+- **VyOS** — **(Now)** — Modernising DPAA1, e.g. adding AF_XDF (adds 'zero copy') support; actively rebuilding ASK as 'ASK2' for the mainline Kernel 6.18 branch used in VyOS 1.5.x 'Rolling'
+
+> **NOTE:** There is a significant divergence between the NXP hard-detached forked kernels, denoted lf-X.X.Y above, and their present mainline Kernel equivalents. There is no route back.
+## 1.2 Choose your own DPAA1/ASK adventure
+
+For an slightly less brief overview of DPAA1 and ASK, read on.
+If you prefer a direct deep dive on this topic, see - [plans/NETWORKING-DEEP-DIVE.md](plans/NETWORKING-DEEP-DIVE.md)
+
+> **NOTE:** It is hard to sufficiently <u>underscore</u> just how much has changed in Linux kernel-land networking since the initial DPAA1 + ASK were created. Less 'new page', more 'entirely new book'. This makes it is significantly more complex and expensive to maintain this legacy code moving forward, than to instead fundamentally rebuild the DPAA1 driver and ASK2 using modern paradigms.
+
+---
+# 2. Overview: Using the DPAA1 Driver(s), Microcode & ASK
+
+Multiple different versions, combinations and capabilities exist under the same 'DPAA1 driver' banner. Lets unpick.
+
+## 2.1 Open Source, but limited: NXP DPAA1 (mainline 4.1-)
+
+NXP DPAA1/Layerscape DPAA, have been around in the mainline Linux Kernel in various iterations since at least 2015, and were first merged in Kernel mainline 4.1.x. [NXP QorIQ SDK 2.0](https://www.nxp.com/docs/en/release-note/QORIQ-SDK-2-0_RN.pdf) release notes echo this, and some quick Kernel tree archaeology unearths the initial Kernel FMAN (network device) commits landed in [Dec 2015](https://github.com/torvalds/linux/commits/f31c00c377ccf07c85442712f7c940a855cb3371/drivers/net/ethernet/freescale/fman?since=2015-12-01&until=2015-12-31), and initial QMan/BMan SoC commits followed within a year in [Sept 2016](https://github.com/torvalds/linux/commits/master/drivers/soc/fsl/qbman?since=2016-09-01&until=2016-09-30). This is an old codebase, with a long legacy.
+
+### 2.1.1 Limitations
+
+The mainline DPAA1 driver is built to leverage the Coarse Classifier functions of the open-source `106.4.18` NXP microcode that is [freely available](https://github.com/nxp-qoriq/qoriq-fm-ucode). As the function's name suggests, this classifier enables comparatively limited functionality of the underlying ASIC, and this microcode version enables comparatively little. In performance terms, this combination was designed for a previous era of Linux networking. A more detailed diff of the available microcode can be found in [arch/dpaa1-architecture](arch/dpaa1-architecture)
+
+## 2.2 Faster, but old: NXP DPAA1 (NXP ASK)
+
+The ASIC within the SoC LS1046A is capable of far greater performance when using an alternative (out-of tree) NXP DPAA1 ASK driver and the proprietary (closed-source) `210.10.1` NXP-signed microcode blob that also ships with the Mono Gateway Development Kit. Critically, this microcode version enables a fine-grain PCD (Parse-Classify-Distribute) classifier along with a wide range of other HW accelerator functions. This makes HW-offloading both far more capable, and more performant.
+
+### 2.2.1 Limitations
+
+The NXP provided DPAA1 driver and ASK, are based on the NXP lf-5.4x LTS Kernel branch. The Kernel 5.4 was released in Nov 2019, and reached End of Life (EoL) in December 2025. It is no longer supported. It is faster, but it still lacks the optimisations and improvements common to modern high-speed networking.
+
+During the development of the Mono Gateway Development Kit, Mono purchased NXP ASK, and with permission, [released the ASK source](https://github.com/we-are-mono/ASK) under GPL v2.0, but the onboard `210.10.1` microcode remains proprietary. This is why [Mono firmware](https://firmware.mono.si/) sits behind authentication.
+
+### 2.2.2 Forward-ports
+
+Mono presented their solution to the (EoL) lf-5.4 kernel [in a video](https://www.youtube.com/watch?v=xRvi3k8XV8E), discussing using supervised AI to port the aging Kernel lf-5.4 NXP DPAA1+ASK code forward to the newer NXP lf-6.12.49 Kernel branch. This is what Mono then shipped in the default [OpenWRT build](https://github.com/we-are-mono/OpenWRT-ASK) installed on the Mono Gateway Development Kits.
+
+Subsequent official [OPNsense builds](https://opnsense.mono.si/) utilised a similar repeat forward-port process of the full NXP lf-5.4 SDK patches + ASK user-space components over to FreeBSD, on which OPNsense is based, along with a Linux-compatibility shim.
+
+---
+# 3. Modernising DPAA1 & ASK for VyOS
+
+The creation of an initial VyOS build for Mono Gateway Development Kits is described in [STARTING-GATE.md](STARTING-GATE.md), and leveraged the VyOS 1.5.x 'Rolling' release sources built for the Kernel 6.6 LTS branch. As porting from lf-5.4 LTS to lf-6.12.49 had been proven by Mono, porting from lf-5.4 to 6.6 LTS for VyOS 'Rolling' for a proof of concept build, proved achievable. Getting this to boot still proved challenging as [STARTING-GATE.md](STARTING-GATE.md) outlines
+
+VyOS 'Rolling' was subsequently rebased from Kernel `6.6.137 LTS` to the near-experimental `6.18 Mainline`, representing a significant shift in the underlying kernel structures and primitives. What was portable from `5.4`, or `6.6` to `6.12`, fundamentally breaks if porting to mainline `6.18`. Too much has changed, and a new approach is now required. 
+
+Rather than continue to carry-forward the now *historical* DPAA1 and ASK codebase, attempting to continue modernising it for more recent Kernel releases, a decision was taken to fundamentally rebuild ASK as ASK2. This enables a more holistic modernisation of both ASK and the DPAA1 driver to utilise modern Kernel networking performance improvements like zero-copy forwarding with AF_XDF.
+
+# 3.1 A Modern DPAA1 Driver
+
+An ongoing effort modernises the mainline DPAA1 driver into a single shared kernel binary (consumed in different runtime modes — kernel `default`, `vpp` AF_XDP, `ask` offload, all shipping in one image) with HW-accelerated AF_XDP and four FMan/QMan hardware offloads. Full design and per-milestone status: [specs/dpaa1-afxdp-modernization-spec.md](specs/dpaa1-afxdp-modernization-spec.md).
+
+**Shipping and board-validated today:**
+
+- **Flavor-ops abstraction (M0)** — per-`dpaa_priv` ops tables, RCU-NULL-safe; byte-identical to mainline when no flavor module is loaded.
+- **AF_XDP zero-copy plumbing (M1–M3-3)** — `ndo_xsk_wakeup`, XSK-backed BMan pool, per-CPU NAPI + dedicated QMan channels per qband, cluster-aware pinning. Driver proven to drop **0%** at line rate; ~5.57 Gbit/s aggregate RX measured (bottleneck is the single userspace receiver, not the NIC).
+- **HW capability layer** — FMan PCD caps live-probed (`0x17` = CC HM POL PARSER on ucode 210).
+- **HM VLAN-strip offload (M3-3c)** — live on hardware (`ethtool -k` → `rx-vlan-offload: on`).
+- **Policer + CEETM scaffolds (M3-3d/e)** — install/stub APIs compiled in and cap-probed, stable contracts for the VyOS CLI consumers.
+
+**What remains for a feature-complete driver** (see the spec's "What remains for a complete DPAA1 driver" table):
+
+- **Two real kernel forward-ports** — the FMan PCD subsystem (unblocks CC steering and the productive HM/Policer datapaths) and the QMan-CEETM driver (~4500 LOC, absent from mainline 6.18, needed for HW egress shaping).
+- **Non-kernel glue** — vyos-1x CLI consumers for HM/Policer/CEETM, a traffic generator for the functional datapath gates, and a multi-core receiver to record the literal ≥7 Gbps figure.
+
+No further *architectural* work is required — the ops abstraction and capability layer already accommodate every remaining consumer.

--- a/HWCTL.md
+++ b/HWCTL.md
@@ -1,51 +1,184 @@
-# Mono Gateway DK — Hardware Control & Diagnostics Cheatsheet
+# Hardware Control & Diagnostics in VyOS for Mono Gateway Development Kit
 
-Hands-on shell recipes for the front-panel LP5812 status LEDs and the
-EMC2305 chassis fan on the LS1046A Mono Gateway running VyOS, plus a
-reference for the built-in `*-check` diagnostic scripts (section 3).
+Additional included helper scripts provide diagnostic status checks, and enable the direct control and customisation of the HW (LED, CPU-Fan). This document provides both an overview of these scripts, and examples of more advanced usage.
 
-Both devices are exposed through standard Linux sysfs interfaces:
+## Quick reference:
 
-| Device   | Subsystem | Path                              |
-|----------|-----------|-----------------------------------|
-| LP5812   | leds      | `/sys/class/leds/<label>/`        |
-| EMC2305  | hwmon     | `/sys/class/hwmon/hwmonN/`        |
-| TMU temp | thermal   | `/sys/class/thermal/thermal_zone3/` |
+```bash
+# LED: status / set colour #hex / RGBW / decimal RGB / decimal RGBW / set off
+led
+sudo led '#336699'
+sudo led '#33669900'
+sudo led 51 102 153
+sudo led 51 102 153 0
+sudo led off
 
-Reads from sysfs work as the `vyos` user. Writes need root: every
-`echo … > /sys/…` below is shown as `echo … | sudo tee /sys/…` so the
-redirection happens in a privileged process. (Plain `sudo echo … > …`
-does **not** work — the redirection is performed by your unprivileged
-shell before `sudo` runs.) If you prefer, drop into a root shell once
-with `sudo -i` and use the bare `echo … > …` form.
+# Fan-check: Status, temps, set-points, PWM control, PWM duty, Fan RPM
+fan-check
 
-`tee` echoes the written value to stdout; append `> /dev/null` to silence
-it when scripting.
+# Fan full
+H=$(dirname "$(grep -l '^emc2305$' /sys/class/hwmon/*/name)")
+sudo systemctl stop fancontrol
+echo 255 | sudo tee $H/pwm1
+
+# Fan back to automatic
+sudo systemctl start fancontrol
+```
 
 ---
 
-## 1. Front-panel LEDs (TI LP5812)
+# 1. Built-in `*-check` diagnostic scripts
 
-The LP5812 is a 12-channel I²C LED controller at `0x6c`, reached through
-the SoC i2c2 controller (`21a0000.i2c`) and the on-board i2c mux (it
-shows up as bus `15-006c` once the mux is enumerated). The DTS wires up
-four of its channels as a single RGBW status indicator. In addition to
-those, the kernel exposes `mmc0::` and the SFP cage LEDs
-(`sfp{0,1}:link`, `sfp{0,1}:activity`).
+Every ISO ships eight self-contained diagnostic reporters plus a `support-bundle` aggregator in `/usr/local/bin/` (sources live in [board/scripts/](board/scripts/)). They share one convention: human-readable sectioned output with `[OK]`/`[WARN]`/`[FAIL]`/`[SKIP]` tags, colour when stdout is a tty, **exit 0 = healthy / 1 = fault / 2 = wrong board or feature absent** — so each doubles as a agios/monit/cron probe. All run as the `vyos` user; a few sections inside them use `sudo` internally where root is needed (e.g. EEPROM and RNG reads).
 
-The LED triggers `heartbeat`, `timer`, `oneshot`, `netdev`, etc. are
-built as **loadable modules** in this kernel — only `none`,
-`disk-activity`, `disk-{read,write}`, `cpu`, `cpu0..3`, `panic`, and
-`mmc0` are visible by default. Load the rest on demand with
-`sudo modprobe ledtrig-<name>` before using sections 1.3 / 1.4.
+| Script           | What it checks                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     | Typical use                                                                                                                                                                                                                                                                                                       |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `dpaa1-check`    | Full DPAA1 networking posture: FMan/QMan/BMan DT nodes + portals, the five built-in drivers (`fsl-fman`, `fsl-fman-port`, `fsl-fman_xmdio`, `fsl_dpaa_mac`,  fsl_dpa`), microcode/MURAM, BMI ports, MEMACs + MDIO buses, PCD capability bits (KeyGen/CC/HM/Policer), jumbo bootarg, eth0–eth4 enumeration, and the AF_XDP counter block.                                                                                                                                                                                                                                                                                                                           | First stop when any network interface is missing or dead. Exit 1 pinpoints which layer of the DPAA1 stack broke.                                                                                                                                                                                                  |
+| `sfp-check`      | Decodes the EEPROM of every inserted SFP/SFP+ module (`ethtool -m`): vendor/PN/rev/serial, connector, transceiver class, bit rate, cable lengths, etc and prints a verdict plus a **paste-ready `SFP_QUIRK_F(...)` line** when it detects a copper 10GBASE-T rollball module masquerading as SR fiber.                                                                                                                                                                                                                                                                                                                                                             | Qualifying a new SFP module. If a module needs a kernel quirk, send the printed block to the maintainer; the patch line drops straight into the `sfp_quirks[]` array (patch `4009`/sibling).                                                                                                                      |
+| `fan-check`      | All 5 thermal zones (ddr, serdes, fman, cluster, sec) tagged `[COOL]`/`[WARM]`/`[HOT]`/`[CRIT]` against the `fan-pid` setpoints, EMC2305 PWM duty (raw + %) and tach RPM, `fan-pid` daemon health + last log lines, and detection of a conflicting legacy `fancontrol`.                                                                                                                                                                                                                                                                                                                                                                                            | Thermal sanity check; exit 1 if `fan-pid` is dead or any zone is at/above crit. **Regression flag:** `pwm1=255 (100%)` here while the daemon journal says `pwm=51` means the broken sysfs PWM path is back in use.                                                                                                |
+| `caam-check`     | CAAM (SEC 5.4) hardware crypto: DT controller node, driver posture (`caam`, `caam_jr` mandatory; `caamalg`/`caamhash`/`caamrng`/`caampkc` optional), active Job Ring count, dmesg banners, CAAM-backed algorithms in `/proc/crypto`, and the hardware RNG (`rng_current` = `caam-rng`, 16-byte sample read). When the ASK offload is engaged it adds a CDX↔SEC FQ wiring section (self-skips otherwise).                                                                                                                                                                                                                                                           | Verifying hardware crypto offload is alive — e.g. before relying on it for IPsec or `/dev/hwrng` entropy.                                                                                                                                                                                                         |
+| `xsk-zc-check`   | The AF_XDP true-zero-copy RX gate counters (`ethtool -S`, default eth3 eth4): `xsk_zc_eligible` / `xsk_zc_rx_armed` / `xsk_fill_guard_block` / `xsk_zc_rx_recovered` plus the wider `xsk_*` block, rendered as the spec §6.1.12 verdict — **dormant** (no ZC bind; the normal shipping state), **ZC-armed** (preconditions met), or **fault** (`xsk_fill_guard_block > 0` / attach-DMA errors — the ZC reprogram WRITE must stay disabled).                                                                                                                                                                                                                        | AF_XDP/VPP datapath debugging on the SFP+ ports. Accepts an interface list: `xsk-zc-check eth3`.                                                                                                                                                                                                                  |
+| `ask-check`      | The ASK2 preview datapath, layer by layer in boot order: dataplane posture, FMan PCD subsystem + MURAM budget, reversible mode switch, hardware classification (FE-VM chain), IPv4 forwarding op-set, `ask.ko` genl control plane, per-interface `offload ask` CLI, and dmesg integrity. Capabilities intentionally outside the preview scope — IPv6, NAT/PAT, VLAN rewrite, IPsec/ESP, bridge/L2 switchdev, multicast/non-TCP-UDP — are reported with the `DEFER` tag (software fallback), never as `[FAIL]`.                                                                                                                                                     | Present in every image; the single command to confirm the plain-routed-IPv4 hardware datapath is healthy. Exit 0 = supported IPv4 datapath operational; 1 = a required capability is missing/broken; `DEFER` lines are expected for this preview.                                                                 |
+| `vpp-check`      | The VPP AF_XDP Zero-Copy status probe: board & kernel posture (isolcpus=3, 2M hugepages >=512), VPP installation & library linkage (libxdp.so check), BPF object & redirect helper (/usr/share/vpp/xdp_redirect.o, xsks_map), VyOS Python integration (control_vpp.py signature), VPP service status & PID, VPP hardware interfaces & zero-copy flags, kernel DPAA1 ZC driver posture (dmesg ZCBIND logs, bpid, defunct netdev handoff), and summary verdict.                                                                                                                                                                                                      | VPP AF_XDP Zero-Copy verification and health check. Exit 0 when VPP is active and AF_XDP Zero-Copy prerequisites are healthy.                                                                                                                                                                                     |
+| `firmware-check` | The complete boot-firmware inventory below the OS: board/SoC identity (DT model, SVR, silicon rev), running U-Boot version vs the copy embedded in QSPI flash, the full `/proc/mtd` partition map with per-partition fingerprints (RCW/PBL preamble, env CRC, FMan-ucode QEF header, recovery-DTB FDT magic, recovery kernel), a deep decode of the running FMan microcode (id, length, SoC code, **proprietary 210.x vs open-source 106.x** classification, md5) cross-checked against the on-flash copy and the kernel's `FMan PCD caps` probe, boot-critical U-Boot env variables + boot targets, and the `/boot/vyos.env` image selector vs the running image. | After any firmware/flash operation, before reporting a bug, or when `add system image` boot selection misbehaves. Run with `sudo` for the full report (flash reads + `fw_printenv`); unprivileged runs skip those sections. A `WARN` on running-vs-flash ucode mismatch means a flash update is pending a reboot. |
+| `support-bundle` | Paste-ready ASK2 issue report: board/kernel identity, non-interactive `show version`, active Ethernet/firewall/VPP offload configuration, live nft/FE-arm/MTU/link state, complete `ask-check` and `firmware-check` output with per-tool exit codes, and a focused kernel-log extract. Never opens an interactive vbash/config session.                                                                                                                                                                                                                                                                                                                            | Run `sudo support-bundle > ask2-bundle.txt` and attach the file to every preview bug report. Aggregate exit 0 = both health checks passed; 1 = one reported a real fault; 2 = wrong board.                                                                                                                        |
 
-> **Day-to-day use:** prefer the shipped [`led`](board/scripts/led.py)
-> helper (section 1.6) — one command, fades, palette, no sysfs paths to
-> remember. The raw sysfs recipes in 1.1–1.5 are the underlying
-> mechanism and the fallback when you need triggers or per-channel
-> control the helper doesn't expose.
+```bash
+# Run everything that applies to this board
+for c in dpaa1-check sfp-check fan-check caam-check xsk-zc-check ask-check vpp-check firmware-check; do
+    echo "== $c =="; "$c"; echo "rc=$?"
+done
 
-### 1.1 Discovery
+# Or, for a bug report, capture one paste-ready file with everything:
+sudo support-bundle > ask2-bundle.txt
+
+# Cron/monitoring probe example (alert on any non-zero exit)
+fan-check >/dev/null || logger -p user.err "fan-check failed rc=$?"
+```
+
+> **NOTE:** Any subsequent diagnostic scripts will also mirror this style convention - IE sectioned reports, colour-tagged results, stdout 0/1/2 exit). Scripts installation is globally defined in `bin/ci-setup-vyos-build.sh`.
+
+---
+
+# 2. The `led` command (helper)
+
+>**NOTE:** By default, the stock LED behaviour of the Mono Gateway Development Kit is **not** modified. The helper enables both static user-set, or programmatic control of the LED in response to user-defined triggers, e.g. indicating traffic throughput.
+
+Every ISO installs [board/scripts/led.py](board/scripts/led.py) as **`/usr/local/bin/led`** a flag-free, Python-stdlib-only CLI that treats the four LP5812 channels as one logical RGBW indicator. Every colour change **fades** from the current state to the target (linear interpolation in raw 8-bit PWM space, 50 ms total), and the helper forces `trigger=none` before writing, so it always works regardless of what trigger was active. Reads work as user `vyos`, but writes require `sudo`.
+
+```bash
+led                      # no args: read and print current state — "R G B W  #RRGGBBWW"
+sudo led off             # fade to all-off
+
+# Palette index (0–31, see below)
+sudo led 17
+
+# Explicit channels, decimal 0–255
+sudo led 255 0 0 0       # R G B W — pure red
+sudo led 0 128 255       # R G B   — W forced to 0
+
+# Hex
+sudo led '#33003300'     # RRGGBBWW (W = white channel, NOT alpha)
+sudo led '#336699'       # RRGGBB — W forced to 0
+
+# Demo / smoke-test modes (Ctrl-C stops and restores 'off')
+sudo led simulate        # jump to a random palette index every 0.1 s
+sudo led simulate 0.5    # ... every 0.5 s
+sudo led steps           # walk the palette 0→31→0 on a triangle wave
+```
+
+> **NOTE:** The first invocation of `led` or `sudo led` following a reboot (to print the LED status) will always return `0 0 0 0 #00000000`. This is expected, as the initial state of the LED is set by U-Boot to indicate the result of the [boot self-test](https://docs.mono.si/gateway-development-kit/getting-started#status-led), prior to VyOS booting. Following successful write via `sudo led`, any subsequent invocation will correctly return the current LED state.
+
+## 2.1 Colour definition format
+
+- 8 digit hex is always parsed as `RRGGBBWW` where `WW` is the white sub-pixel channel, **NOT** alpha
+- 6 digit hex is parsed as a standard sRGB hex colour *only* when `#`-prefixed, or containing a hex letter (`a–f`)
+- A bare decimal token e.g `1` is parsed as a palette index. (see §2.3)
+ 
+>**NOTE:** When in doubt, prefix any hex code with `#`.
+
+## 2.2 RGBW LED Colour representation
+
+The colour volume (representation) of the included RGBW LED deviates significantly from that expected when defined using colours referenced to the sRGB colour space. Like any device, this RGBW LED is imperfect, and excessive use of the white sub-pixel will notably both skew-blue, and eventually wash-out the intended colour. If a particular hue is desired, experimentation to define the necessary RGBW balance is required.
+
+> **NOTE:** This LED is incredibly bright even without the white sub-pixel. Unless attempting to script a 'disco-mode', start by specifying only RRGGBB values, and omit the white pixel entirely, unless explicitly required.
+
+## 2.3 Colour palette index
+
+The default colour palette defined in [board/scripts/led.py](board/scripts/led.py) provides an baked-in 32-entry indexed ramp intended for use as a network-load indicator. This behaviour is not active by default, but the index steps may still be invoked directly via `sudo led`. Indices are stable across VyOS builds, ensuring any user-scripts which rely on a set index step will working as expected. The index steps are graduated by both LED brightness and colour. This provides a relative indication, at a glance, of both traffic load (brightness) and throughput (colour).
+
+|                |           |       |       |       |       |                |                      |
+| -------------- | --------- | ----- | ----- | ----- | ----- | -------------- | -------------------- |
+| **Index step** | **~Mbps** | **R** | **G** | **B** | **W** | **HEX (RGBW)** | **IRL appearance**   |
+| 0              | 312.5     | 0     | 2     | 0     | 0     | \#00020000     | v.v.v. dim green     |
+| 1              | 625       | 0     | 8     | 0     | 0     | \#00080000     | v.v. dim light green |
+| 2              | 937.5     | 0     | 16    | 0     | 0     | \#00100000     | v. dim light green   |
+| 3              | 1250      | 0     | 32    | 0     | 0     | \#00200000     | dim green            |
+| 4              | 1562.5    | 8     | 32    | 0     | 0     | \#08200000     | dim green/yellow     |
+| 5              | 1875      | 16    | 32    | 0     | 0     | \#10200000     | dim yellow/green     |
+| 6              | 2187.5    | 32    | 24    | 0     | 0     | \#20180000     | dim yellow           |
+| 7              | 2500      | 48    | 16    | 0     | 0     | \#30100000     | dim yellow/orange    |
+| 8              | 2812.5    | 64    | 8     | 0     | 0     | \#40080000     | dim orange           |
+| 9              | 3125      | 80    | 0     | 0     | 0     | \#50000000     | dark orange/red      |
+| 10             | 3437.5    | 96    | 8     | 0     | 0     | \#60080000     | dark orange/amber    |
+| 11             | 3750      | 128   | 16    | 0     | 0     | \#80100000     | dark amber           |
+| 12             | 4062.5    | 160   | 8     | 0     | 0     | \#a0080000     | amber                |
+| 13             | 4375      | 160   | 16    | 0     | 0     | \#a0100000     | bright amber         |
+| 14             | 4687.5    | 160   | 16    | 2     | 0     | \#a0100200     | amber/pink           |
+| 15             | 5000      | 160   | 16    | 8     | 0     | \#a0100800     | pink/amber           |
+| 16             | 5312.5    | 128   | 16    | 16    | 0     | \#80101000     | bright pink          |
+| 17             | 5625      | 96    | 16    | 16    | 0     | \#60101000     | pink/purple          |
+| 18             | 5937.5    | 96    | 16    | 24    | 4     | \#60101804     | purple               |
+| 19             | 6250      | 64    | 8     | 24    | 8     | \#40081808     | purple/white         |
+| 20             | 6562.5    | 32    | 8     | 16    | 16    | \#20081010     | white/purple         |
+| 21             | 6875      | 8     | 0     | 8     | 32    | \#08000820     | dim white            |
+| 22             | 7187.5    | 0     | 0     | 0     | 64    | \#00000040     | off-white            |
+| 23             | 7500      | 0     | 0     | 32    | 64    | \#00002040     | neutral white        |
+| 24             | 7812.5    | 0     | 0     | 64    | 64    | \#00004040     | cool white           |
+| 25             | 8125      | 0     | 0     | 96    | 32    | \#00006020     | ice white            |
+| 26             | 8437.5    | 0     | 0     | 112   | 16    | \#00007010     | ice blue             |
+| 27             | 8750      | 0     | 0     | 144   | 8     | \#00009008     | light blue           |
+| 28             | 9062.5    | 0     | 0     | 160   | 0     | \#0000a000     | dim dark blue        |
+| 29             | 9375      | 0     | 0     | 192   | 0     | \#0000c000     | dark blue            |
+| 30             | 9687.5    | 0     | 0     | 224   | 0     | \#0000e000     | bright Blue          |
+| 31             | 10000     | 0     | 0     | 255   | 0     | \#0000ff00     | v.bright Blue        |
+## 2.4 Sane defaults and exit codes
+
+**No runtime knobs by design:** fade time (`FADE_MS = 50`), frame rate, palette, and demo cadence are constants at the top of the script. There is no config file and no on-disk state. Permanent re-tuning requires editing `board/scripts/led.py` in this repo and rebuilding the ISO.
+
+**Exit codes:** `0` ok · `1` LP5812 driver missing · `2` bad arguments · `3` sysfs write failed (this usually indicates a missed `sudo`).
+
+---
+
+# 3. Advanced configuration
+
+As the overview of these helper scripts hints, they can enable functionality beyond assessing the status of the HW, including:
+
+- Using the LED as a \<trigger\> indicator, e.g.:
+	- Using the LED as a network activity indicator
+	- Pulsing the LED as a CPU-load driven heartbeat
+- Setting boot-time defaults for LED behaviour
+- Manual override of CPU-fan (for debug only)
+- Controlling the CPU F_1 and F_2 fans via PID loop
+ 
+Fundamental to all advanced configuration is the discovery and enumeration of the hardware devices, communication interface addresses, and the associated sysfs objects with which scripts may usefully interact. Broadly, these are split along three paths:
+
+| Device   | Subsystem | Path                                |
+| -------- | --------- | ----------------------------------- |
+| LP5812   | leds      | `/sys/class/leds/<label>/`          |
+| EMC2305  | hwmon     | `/sys/class/hwmon/hwmonN/`          |
+| TMU temp | thermal   | `/sys/class/thermal/thermal_zoneN/` |
+>**NOTE:** Following sections frequently modify sysfs objects. Reads from sysfs will work as the `vyos` user, but writes require root. Every `echo … > /sys/…` below is shown as `echo … | sudo tee /sys/…` to ensure the redirection occurs in the privileged process. A plain `sudo echo … > …` will **not** work, as the redirection is performed by the unprivileged shell before `sudo` executes. `tee` echoes the written value to stdout, but appending `> /dev/null` silences this output, which is useful when scripting. 
+
+>**NOTE:** If preferred, invoke a `root` shell directly via `sudo -i`, and then use the bare `echo … > …` form of the commands shown. However, the usual warnings and disclaimers apply here, as misuse of `root` may render your VyOS installation useable.
+
+## 3.1 Front-panel LEDs (TI LP5812)
+
+> **NOTE:** For day-to-day usage, use the [`led`](board/scripts/led.py) helper (see §2.). This provides a singular means to control colour, fades and an indexed palette with no sysfs paths to remember. The raw sysfs recipes discussed here use the same underlying mechanism, and provide a fallback option when you need specific triggers or per-channel control which the helper doesn't expose.
+
+The [LP5812](https://www.ti.com/lit/ds/symlink/lp5812.pdf?ts=1782652167518) is a 12-channel I²C LED controller at `0x6c`, reached through the SoC I²C2 controller (`21a0000.i2c`) and the on-board I²C mux (it shows up as bus `15-006c` once the mux is enumerated). The device tree source (DTS) wires up the four LED channels as a single RGBW status indicator. 
+
+### 3.1.1 Device discovery
 
 ```bash
 # List the LEDs the kernel has registered
@@ -65,7 +198,9 @@ cat $LED/brightness            # current value
 cat $LED/trigger               # available + active trigger (active is in [brackets])
 ```
 
-### 1.2 Manual on/off / dim
+### 3.1.2 Manual on/off/dim
+
+If you're curious what the `led` helper does under the hood, this is it.
 
 ```bash
 # Solid green at full brightness
@@ -80,11 +215,17 @@ for c in white blue green red; do
 done
 ```
 
-> A trigger must be `none` for manual writes to stick. If a trigger is
-> active, set it back to `none` first:
-> `echo none | sudo tee /sys/class/leds/status:green/trigger`.
+>**NOTE:** A trigger must be `none` for manual writes to stick. If a trigger is active, set it back to `none` first: `echo none | sudo tee /sys/class/leds/status:green/trigger`.
 
-### 1.3 Heartbeat / timer / oneshot triggers
+## 3.1.3 Triggers
+
+A range of system activity states can be used to trigger LED behaviour. Some are enabled by default, whilst others require specific kernel modules to be loaded on-demand.
+
+By default, `none`, `disk-activity`, `disk-{read,write}`, `cpu`, `cpu0..3`, `panic`, and `mmc0` are usable for defining the LED state. The kernel exposes `mmc0::` and the SFP cage LEDs (`sfp{0,1}:link`, `sfp{0,1}:activity`) as well, which can be directly mirrored.
+
+Via additional **loadable kernel modules** built for this kernel, `heartbeat`, `timer`, `oneshot`, `netdev`, etc, may also be used. To load these on-demand use `sudo modprobe ledtrig-<name>`.
+
+### 3.1.4 Heartbeat / timer / oneshot triggers
 
 Load the trigger modules first (they are not auto-loaded):
 
@@ -93,6 +234,8 @@ sudo modprobe ledtrig-heartbeat
 sudo modprobe ledtrig-timer
 sudo modprobe ledtrig-oneshot
 ```
+
+> **NOTE:** To persistently load a desired module across reboots, place a named `.conf` e.g. "my_modules.conf" in `/etc/modules-load.d/` that contains the module name. If loading multiple modules, declare one per line.
 
 ```bash
 LED=/sys/class/leds/status:blue
@@ -117,7 +260,7 @@ echo none | sudo tee $LED/trigger
 echo 0    | sudo tee $LED/brightness
 ```
 
-### 1.4 Network activity (LEDS_TRIGGER_NETDEV)
+### 3.1.5 Network activity (LEDS_TRIGGER_NETDEV)
 
 `CONFIG_LEDS_TRIGGER_NETDEV=m` is enabled, so any LED can mirror an
 interface's link / TX / RX state once the module is loaded:
@@ -138,62 +281,14 @@ echo 50     | sudo tee $LED/interval      # blink interval (ms)
 ```
 
 Use this to wire WAN-link, VPN-up, or per-port indicators without any
-userspace daemon.
+user-space daemon.
 
-### 1.6 The `led` command (shipped helper)
+### 3.1.6 Boot-time defaults
 
-Every ISO installs [board/scripts/led.py](board/scripts/led.py) as
-**`/usr/local/bin/led`** — a flag-free, Python-stdlib-only CLI that
-treats the four LP5812 channels as one logical RGBW indicator. Every
-colour change **fades** from the current state to the target (linear
-interpolation in raw 8-bit PWM space, 50 ms total), and the helper
-forces `trigger=none` before writing, so it always works regardless of
-what trigger was active. Reads work as `vyos`; writes need `sudo`.
+To make the LEDs come up in a particular defined state on every boot, drop a oneshot
+systemd unit which defines the desired behaviour. This will then execute when VyOS boots
 
-```bash
-led                      # no args: print current state — "R G B W  #RRGGBBWW"
-sudo led off             # fade to all-off
-
-# Palette index (0–31, see below)
-sudo led 17
-
-# Explicit channels, decimal 0–255
-sudo led 255 0 0 0       # R G B W — pure red
-sudo led 0 128 255       # R G B   — W forced to 0
-
-# Hex
-sudo led '#33003300'     # RRGGBBWW (W = white channel, NOT alpha)
-sudo led '#336699'       # RRGGBB — W forced to 0
-
-# Demo / smoke-test modes (Ctrl-C stops and restores 'off')
-sudo led simulate        # jump to a random palette index every 0.1 s
-sudo led simulate 0.5    # ... every 0.5 s
-sudo led steps           # walk the palette 0→31→0 on a triangle wave
-```
-
-**Token disambiguation:** 8 hex digits always parse as `RRGGBBWW`;
-6 digits parse as hex only when `#`-prefixed or containing a hex letter
-(`a–f`) — a bare decimal token is a palette index. When in doubt,
-prefix hex with `#`.
-
-**The palette** is a baked-in 32-entry ramp designed as a
-network-load indicator: index 0 = faint grey idle baseline, 1–8 ramp
-through red, 9–15 orange/amber, 16–20 yellow→yellow-white, 21–25
-cooling whites, 26–31 blue-white "overdrive" up to maximum. Indices are
-stable across upgrades — scripts that hard-code an index keep working.
-
-**No runtime knobs by design:** fade time (`FADE_MS = 50`), frame rate,
-palette, and demo cadence are constants at the top of the script. There
-is no config file and no on-disk state — permanent re-tuning means
-editing `board/scripts/led.py` in this repo and rebuilding the ISO.
-
-**Exit codes:** `0` ok · `1` LP5812 driver missing · `2` bad arguments
-· `3` sysfs write failed (usually: forgot `sudo`).
-
-### 1.7 Boot-time defaults
-
-To make the LEDs come up in a known state on every boot, drop a oneshot
-unit on the running system:
+e.g: To use the link-state of eth0 as a trigger for a solid active/on green LED channel, and using CPU load to 'heartbeat' pulse on the Blue LED:
 
 ```bash
 cat >/etc/systemd/system/mono-leds.service <<'EOF'
@@ -218,28 +313,26 @@ systemctl daemon-reload
 systemctl enable --now mono-leds.service
 ```
 
+>**NOTE:** For the above example to actually function as desired, also ensure the dependent kernel modules are loaded at boot, see §3.1.4
+
 ---
 
-## 2. Chassis fan (Microchip EMC2305)
+## 3.2 Chassis fan (Microchip EMC2305)
 
-The EMC2305 is a 5-channel PWM fan controller at `0x2e`, reached via the
-SoC i2c0 controller (`2180000.i2c`) and the on-board mux (visible as
-bus `7-002e`). Channel 1 (`pwm1` / `fan1_input`) drives the chassis
-fan; channel 2 (`pwm2` / `fan2_input`) is wired but currently unused
-(reads `fan2_input = 0`). The other three channels are not exported by
-the DTS.
+>**WARNING:** Exercise caution. Unlike modern x86 CPUs which have extensive thermal-throttling and emergency thermal-shutdown protections, there are limited over-temperature controls on embedded device SoCs like the LS1046A. Thermal runaway may occur if thermal load exceeds cooling capacity risking permanent damage to the SoC.
 
-The in-kernel `emc2305` driver in this build only exposes the raw `pwmN`
-and `fanN_input` / `fanN_fault` attributes — there is **no
-`pwmN_enable`**, **no `fanN_alarm`**, **no `fanN_min`**, and **no
-`temp*`** node on this hwmon. "Manual mode" therefore just means
-*stopping the userspace daemon and writing pwm1 yourself*.
+The EMC2305 is a 5-channel PWM fan controller at `0x2e`, reached via the SoC I²C0 controller (`2180000.i2c`) and the on-board mux (visible as bus `7-002e`). Channel 1 (`pwm1` / `fan1_input`) drives the chassis fan; channel 2 (`pwm2` / `fan2_input`) is wired but currently unused (reads `fan2_input = 0`). The other three channels are not exported by the Device Tree Source (DTS).
 
-In normal operation the **`fancontrol` daemon owns the fan** —
-configuration lives in `/etc/fancontrol`, regenerated on each boot by
-`fancontrol-setup.sh` to absorb the unstable `hwmonN` numbering.
+The in-kernel `emc2305` driver in this build only exposes the raw `pwmN` and `fanN_input` / `fanN_fault` attributes. There is **no `pwmN_enable`**, **no `fanN_alarm`**, **no `fanN_min`**, and **no
+`temp*`** node on this hwmon device. 
 
-### 2.1 Discovery
+During normal operations, the CPU fan is controlled by `fan-pid`, a self-contained Python 3 multi-zone [PID controller](https://en.wikipedia.org/wiki/PID_controller) which takes input from all five LS1046A thermal zones (cluster\[SoC\], DDR, SerDes, Fman, CAAM). The hottest thermal zone dictates the PID loop managed fan RPM setpoint, whilst additional policy controls clamp and smooth RPM changes to further minimise noise. A measure of fault-tolerance is achieved using last-known values should a sensor become unreadable or unresponsive. As a self-contained solution, the full operating logic is defined within [board/scripts/fan-pid.py](board/scripts/fan-pid.py).
+
+See [data/hooks/98-fancontrol.chroot](data/hooks/98-fancontrol.chroot) for the rationale behind masking the upstream alternative`fancontrol.service` defensively (as two PWM controllers must **never** run concurrently).
+
+### 3.2.1 Device discovery
+
+Enumeration for emc2305 is slightly complicated by variation in the assigned hwmon device number, but is trivially determined and brought into active control by `fan-pid`
 
 ```bash
 # Find the EMC2305 hwmon device (number varies across boots!)
@@ -254,10 +347,12 @@ ls $H
 for z in /sys/class/thermal/thermal_zone*; do
     printf '%s = %s\n' "$z" "$(cat $z/type)"
 done
-# core-cluster is the one driving the fan curve
+# The fan curve response is based on the core-cluster temperature sensor value
 ```
 
-### 2.2 Read-only inspection (safe, daemon stays running)
+### 3.2.2 Manually read-only inspection (safe)
+
+>**NOTE:** For day-to-day use run the `fan-check` diagnostic script.
 
 ```bash
 H=$(dirname "$(grep -l '^emc2305$' /sys/class/hwmon/*/name)")
@@ -272,141 +367,30 @@ awk '{printf "%.1f °C\n", $1/1000}' \
     /sys/class/thermal/thermal_zone3/temp
 
 # Daemon status & current decisions
-systemctl status fancontrol
-journalctl -u fancontrol -n 30 --no-pager
+systemctl status fan-pid
+journalctl -u fan-pid -n 30 --no-pager
 ```
 
-### 2.3 Manual override (test / debug)
+### 3.2.3 Manual override (test / debug only)
 
-> Stop the daemon first, otherwise it will overwrite your PWM within
-> `INTERVAL` seconds (default 10 s).
+> **NOTE:** The design of 'fan-pid' provides an easy method to test 100% PWM fan duty, as  defensively, this is set as the final act when stopping this daemon.
+
+The `fan-control` script, returns all relevant thermal and fan data along with the output of `sudo systemctl status fan-check.service` with which to validate the responsiveness of the emc2305 controller to `fan-pid` inputs.
+
+For diagnostic purposes, if setting CPU fan RPM to 100% is required, this can be achieved by simply stopping the fan-pid service.
 
 ```bash
-H=$(dirname "$(grep -l '^emc2305$' /sys/class/hwmon/*/name)")
-
-sudo systemctl stop fancontrol
-
-echo 51  | sudo tee $H/pwm1           # spin-up minimum (~1700 RPM, EMC2305 floor)
-sleep 3; cat $H/fan1_input
-
-echo 128 | sudo tee $H/pwm1           # ~50%
-sleep 3; cat $H/fan1_input
-
-echo 255 | sudo tee $H/pwm1           # full speed
-sleep 3; cat $H/fan1_input
-
-echo 0   | sudo tee $H/pwm1           # off (fan will coast then stop)
+sudo systemctl stop fan-pid.service   # Defensively sets CPU fan RPM 100%
+sudo systemctl start fan-pid.service  # PID loop pulses slows to required RPM
+fan-check                             # Print all temps, duty and RPM setpoints
 ```
 
-> **Note**: PWM values below ~51 are quantized to off by the EMC2305;
-> there is no smooth ramp from 0. The minimum *running* duty is 51.
+>**NOTE:** Ensure you restart the fan-pid service. If the fans sound like a jet-engine, the defensive 100% setting is still active. Confirm status using `fan-check` or `sudo systemctl status fan-pid.service` directly.
 
-Hand control back to the daemon (it re-asserts `pwm1` on the next tick):
+### 3.2.4 Controlling the CPU F_1 and F_2 fans via PID loop
 
-```bash
-sudo systemctl start fancontrol
-```
+The [PID loop](https://en.wikipedia.org/wiki/PID_controller) used by `fan-pid` (See: [fan-pid](/board/scripts/fan-pid)) should greatly reduce the need for (any) manual intervention or tweaking of the fan-curve by through effective adaption to environmental conditions.
 
-### 2.4 Tweaking the curve permanently
+However, if required, the setpoints for each thermal zone, along with I- and P- term gains constants can be set within the fan-pid script. Restart the service to see the effect of changes.
 
-The active curve is a linear ramp 40 °C (off) → 80 °C (full). To change
-it on a running system edit `/etc/fancontrol`:
-
-```bash
-$EDITOR /etc/fancontrol
-# Adjust MINTEMP / MAXTEMP / MINSTART / MINSTOP / MAXPWM as needed
-systemctl restart fancontrol
-```
-
-> **Stale on current builds:** the lm-sensors `fancontrol` stack (and its
-> `fancontrol.conf` template) was removed and replaced by the multi-zone PID
-> daemon [board/scripts/fan-pid](board/scripts/fan-pid) (`fan-pid.service`).
-> Zone setpoints and gains are constants at the top of that script — edit it
-> in the source repo and rebuild the ISO for permanent changes.
-
-### 2.5 Power / fault check
-
-```bash
-H=$(dirname "$(grep -l '^emc2305$' /sys/class/hwmon/*/name)")
-
-# Fan stalled / unplugged?
-cat $H/fan1_fault           # 1 = no tach pulses
-
-# Temperature cooling check (full ramp)
-sudo systemctl stop fancontrol
-echo 255 | sudo tee $H/pwm1
-for i in $(seq 1 12); do
-    awk -v p="$(cat $H/pwm1)" -v r="$(cat $H/fan1_input)" \
-        -v t="$(cat /sys/class/thermal/thermal_zone3/temp)" \
-        'BEGIN{printf "pwm=%s rpm=%s temp=%.1fC\n", p, r, t/1000}'
-    sleep 5
-done
-sudo systemctl start fancontrol
-```
-
----
-
-## 3. Built-in diagnostics — the `*-check` scripts
-
-Every ISO ships eight self-contained diagnostic reporters plus a
-`support-bundle` aggregator in
-`/usr/local/bin/` (sources live in
-[board/scripts/](board/scripts/)). They share one convention:
-human-readable sectioned output with `[OK]`/`[WARN]`/`[FAIL]`/`[SKIP]`
-tags, colour when stdout is a tty, **exit 0 = healthy / 1 = fault /
-2 = wrong board or feature absent** — so each doubles as a
-Nagios/monit/cron probe. All run as the `vyos` user; a few sections
-inside them use `sudo` internally where root is needed (e.g. EEPROM and
-RNG reads).
-
-| Script | What it checks | Typical use |
-|--------|----------------|-------------|
-| `dpaa1-check` | Full DPAA1 networking posture: FMan/QMan/BMan DT nodes + portals, the five built-in drivers (`fsl-fman`, `fsl-fman-port`, `fsl-fman_xmdio`, `fsl_dpaa_mac`, `fsl_dpa`), microcode/MURAM, BMI ports, MEMACs + MDIO buses, PCD capability bits (KeyGen/CC/HM/Policer), jumbo bootarg, eth0–eth4 enumeration, and the AF_XDP counter block. | First stop when any network interface is missing or dead. Exit 1 pinpoints which layer of the DPAA1 stack broke. |
-| `sfp-check` | Decodes the EEPROM of every inserted SFP/SFP+ module (`ethtool -m`): vendor/PN/rev/serial, connector, transceiver class, bit rate, cable lengths — and prints a verdict plus a **paste-ready `SFP_QUIRK_F(...)` line** when it detects a copper 10GBASE-T rollball module masquerading as SR fiber. | Qualifying a new SFP module. If a module needs a kernel quirk, send the printed block to the maintainer; the patch line drops straight into the `sfp_quirks[]` array (patch `4009`/sibling). |
-| `fan-check` | All 5 thermal zones (ddr, serdes, fman, cluster, sec) tagged `[COOL]`/`[WARM]`/`[HOT]`/`[CRIT]` against the `fan-pid` setpoints, EMC2305 PWM duty (raw + %) and tach RPM, `fan-pid` daemon health + last log lines, and detection of a conflicting legacy `fancontrol`. | Thermal sanity check; exit 1 if `fan-pid` is dead or any zone is at/above crit. **Regression flag:** `pwm1=255 (100%)` here while the daemon journal says `pwm=51` means the broken sysfs PWM path is back in use. |
-| `caam-check` | CAAM (SEC 5.4) hardware crypto: DT controller node, driver posture (`caam`, `caam_jr` mandatory; `caamalg`/`caamhash`/`caamrng`/`caampkc` optional), active Job Ring count, dmesg banners, CAAM-backed algorithms in `/proc/crypto`, and the hardware RNG (`rng_current` = `caam-rng`, 16-byte sample read). When the ASK offload is engaged it adds a CDX↔SEC FQ wiring section (self-skips otherwise). | Verifying hardware crypto offload is alive — e.g. before relying on it for IPsec or `/dev/hwrng` entropy. |
-| `xsk-zc-check` | The AF_XDP true-zero-copy RX gate counters (`ethtool -S`, default eth3 eth4): `xsk_zc_eligible` / `xsk_zc_rx_armed` / `xsk_fill_guard_block` / `xsk_zc_rx_recovered` plus the wider `xsk_*` block, rendered as the spec §6.1.12 verdict — **dormant** (no ZC bind; the normal shipping state), **ZC-armed** (preconditions met), or **fault** (`xsk_fill_guard_block > 0` / attach-DMA errors — the ZC reprogram WRITE must stay disabled). | AF_XDP/VPP datapath debugging on the SFP+ ports. Accepts an interface list: `xsk-zc-check eth3`. |
-| `ask-check` | The ASK2 preview datapath, layer by layer in boot order: dataplane posture, FMan PCD subsystem + MURAM budget, reversible mode switch, hardware classification (FE-VM chain), IPv4 forwarding op-set, `ask.ko` genl control plane, per-interface `offload ask` CLI, and dmesg integrity. Capabilities intentionally outside the preview scope — IPv6, NAT/PAT, VLAN rewrite, IPsec/ESP, bridge/L2 switchdev, multicast/non-TCP-UDP — are reported with the `DEFER` tag (software fallback), never as `[FAIL]`. | Present in every image; the single command to confirm the plain-routed-IPv4 hardware datapath is healthy. Exit 0 = supported IPv4 datapath operational; 1 = a required capability is missing/broken; `DEFER` lines are expected for this preview. |
-| `vpp-check` | The VPP AF_XDP Zero-Copy status probe: board & kernel posture (isolcpus=3, 2M hugepages >=512), VPP installation & library linkage (libxdp.so check), BPF object & redirect helper (/usr/share/vpp/xdp_redirect.o, xsks_map), VyOS Python integration (control_vpp.py signature), VPP service status & PID, VPP hardware interfaces & zero-copy flags, kernel DPAA1 ZC driver posture (dmesg ZCBIND logs, bpid, defunct netdev handoff), and summary verdict. | VPP AF_XDP Zero-Copy verification and health check. Exit 0 when VPP is active and AF_XDP Zero-Copy prerequisites are healthy. |
-| `firmware-check` | The complete boot-firmware inventory below the OS: board/SoC identity (DT model, SVR, silicon rev), running U-Boot version vs the copy embedded in QSPI flash, the full `/proc/mtd` partition map with per-partition fingerprints (RCW/PBL preamble, env CRC, FMan-ucode QEF header, recovery-DTB FDT magic, recovery kernel), a deep decode of the running FMan microcode (id, length, SoC code, **proprietary 210.x vs open-source 106.x** classification, md5) cross-checked against the on-flash copy and the kernel's `FMan PCD caps` probe, boot-critical U-Boot env variables + boot targets, and the `/boot/vyos.env` image selector vs the running image. | After any firmware/flash operation, before reporting a bug, or when `add system image` boot selection misbehaves. Run with `sudo` for the full report (flash reads + `fw_printenv`); unprivileged runs skip those sections. A `WARN` on running-vs-flash ucode mismatch means a flash update is pending a reboot. |
-| `support-bundle` | Paste-ready ASK2 issue report: board/kernel identity, non-interactive `show version`, active Ethernet/firewall/VPP offload configuration, live nft/FE-arm/MTU/link state, complete `ask-check` and `firmware-check` output with per-tool exit codes, and a focused kernel-log extract. Never opens an interactive vbash/config session. | Run `sudo support-bundle > ask2-bundle.txt` and attach the file to every preview bug report. Aggregate exit 0 = both health checks passed; 1 = one reported a real fault; 2 = wrong board. |
-
-```bash
-# Run everything that applies to this board
-for c in dpaa1-check sfp-check fan-check caam-check xsk-zc-check ask-check vpp-check firmware-check; do
-    echo "== $c =="; "$c"; echo "rc=$?"
-done
-
-# Or, for a bug report, capture one paste-ready file with everything:
-sudo support-bundle > ask2-bundle.txt
-
-# Cron/monitoring probe example (alert on any non-zero exit)
-fan-check >/dev/null || logger -p user.err "fan-check failed rc=$?"
-```
-
-> When adding a new diagnostic, mirror this style (sectioned report,
-> tag set, 0/1/2 exit convention) and wire the install in
-> `bin/ci-setup-vyos-build.sh` alongside the existing diagnostics.
-
----
-
-## Quick reference
-
-```bash
-# LED: current state / colour / off (shipped helper, see 1.6)
-led
-sudo led '#336699'
-sudo led off
-
-# LED raw sysfs on/off
-echo 255 | sudo tee /sys/class/leds/status:red/brightness
-echo 0   | sudo tee /sys/class/leds/status:red/brightness
-
-# Fan full
-H=$(dirname "$(grep -l '^emc2305$' /sys/class/hwmon/*/name)")
-sudo systemctl stop fancontrol
-echo 255 | sudo tee $H/pwm1
-
-# Fan back to automatic
-sudo systemctl start fancontrol
-```
+>**NOTE:** Local modification is possible, but will not persist across a reboot. Edits in the source repo and rebuilding the ISO are required to affect permanent changes.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,7 +31,7 @@ Review the [open issues](https://github.com/mihakralj/vyos-ls1046a-build/issues)
 
 Download the latest `vyos-...-LS1046A-arm64.iso` from [Releases](https://github.com/mihakralj/vyos-ls1046a-build/releases).
 
-> **Note:** The ISO is a hybrid image — write it as a raw disk image, not as extracted files. No decompression or FAT32 formatting needed.
+> **NOTE:** The ISO is a hybrid image — write it as a raw disk image, not as extracted files. No decompression or FAT32 formatting needed.
 
 ### Linux
 
@@ -46,7 +46,7 @@ sudo umount /dev/sdX* 2>/dev/null
 sudo dd if=vyos-*-LS1046A-arm64.iso of=/dev/sdX bs=4M status=progress conv=fsync
 ```
 
-### macOS
+### MacOS
 
 ```bash
 # Identify USB device
@@ -87,9 +87,9 @@ This loads `boot.scr` from the USB FAT32 partition, which loads the kernel, DTB,
 
 Watch the boot log for 60–90 seconds until the VyOS login prompt appears.
 
-> **If `usb start` hangs or shows no devices:** Try a USB 2.0 drive. Some USB 3.0 drives aren't detected by the LS1046A USB controller.
+>**NOTE:** If `usb start` hangs or shows no devices, try a USB 2.0 drive. Some USB 3.0 drives aren't detected by the LS1046A USB controller.
 
-> **USB layout:** The hybrid ISO has two partitions when written to USB: partition 1 (ISO9660 with squashfs) and partition 2 (FAT32 with boot files). U-Boot loads from partition 2 explicitly via `fatload usb 0:2`. After kernel boot, live-boot finds the squashfs on the ISO9660 partition.
+> **NOTE:** The hybrid ISO has two partitions when written to USB: partition 1 (ISO9660 with squashfs) and partition 2 (FAT32 with boot files). U-Boot loads from partition 2 explicitly via `fatload usb 0:2`. After kernel boot, live-boot finds the squashfs on the ISO9660 partition.
 
 ---
 
@@ -119,7 +119,7 @@ reboot
 
 The board will boot VyOS from eMMC automatically. No manual U-Boot configuration needed.
 
-> **First boot may fail once:** After a fresh eMMC format, U-Boot's ext4 driver occasionally fails to read the new filesystem on the very first attempt (`Failed to load '/boot/vyos.env'`). This is a known U-Boot quirk — just reboot again from the recovery shell and it will work.
+>**NOTE:** First boot may fail once. After a fresh eMMC format, U-Boot's ext4 driver occasionally fails to read the new filesystem on the very first attempt (`Failed to load '/boot/vyos.env'`). This is a known U-Boot quirk — just reboot again from the recovery shell and it will work.
 
 ---
 
@@ -142,7 +142,7 @@ add system image <url>
 
 After the upgrade completes, `/boot/vyos.env` is automatically updated to the new image. Reboot when ready.
 
-> **Never use `install image` on an already-installed system.** Use `add system image` instead. `install image` repartitions the eMMC and is only for fresh installs from USB live sessions.
+> **WARNING:** Never use `install image` on an already-installed system. Use `add system image` instead. `install image` repartitions the eMMC and is only for fresh installs from USB live sessions.
 
 ---
 
@@ -276,13 +276,19 @@ chmod 600 ~/.ssh/id_vyos
 ssh-keygen -y -f ~/.ssh/id_vyos_vanity > ~/.ssh/id_vyos_vanity.pub
 ```
 
-> **Note:** This key is shipped openly with the image as a convenience credential for first-boot and recovery access. Treat any device exposed to an untrusted network as compromised until you replace this key with your own and remove the vanity entry from `system login user vyos authentication public-keys`.
+> **NOTE:** This key is shipped openly with the image as a convenience credential for first-boot and recovery access. Treat any device exposed to an untrusted network as compromised until you replace this key with your own and remove the vanity entry from `system login user vyos authentication public-keys`.
 
 ---
 
-## See Also
+## See Also:
 
-- **[plans/FIRMWARE.md](plans/FIRMWARE.md)** — Board firmware update (NOR + eMMC flash procedure, partition offset details, recovery)
-- **[plans/BOOT-PROCESS.md](plans/BOOT-PROCESS.md)** — Complete technical specification: U-Boot environment, memory map, clock tree, USB and eMMC boot sequences, `vyos.env` write paths, DTB delivery, kexec prevention, SPI NOR layout, and failure modes
-- **[plans/archive/UBOOT.md](plans/archive/UBOOT.md)** — (Archived) former U-Boot reference, consolidated into `BOOT-PROCESS.md`
-- **[plans/PORTING.md](plans/PORTING.md)** — Why 13 things were broken and how each was fixed
+| **I want to...**                 | **Go to...**                                                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Understand the HW**            | [HARDWARE.md](HARDWARE.md): Physical HW, boot-chain and known quirks                                                |
+| **Update the Firmware**          | [FIRMWARE.md](FIRMWARE.md): A *'how-to'* guide                                                                      |
+| **Control HW & diagnose issues** | [HWCTL.md](HWCTL.md):  Control the main LEDs with `led` & diagnose issues with the seven built-in `*-check` scripts |
+| **Understand HW-Offloading**     | [HW-OFFLOADING.md](HW-OFFLOADING.md): Overview of the DPAA1/ASK network architecture                                |
+| **Manage VyOS via a web UI**     | [VYMANAGER.md](VYMANAGER.md): Manage VyOS using the Vymanager SDN controller & web GUI                              |
+| **See how this started**         | [STARTING-GATE.md](STARTING-GATE.md): Getting mainline VyOS to work (at all)                                        |
+| **See what's changed**           | [plans/CHANGELOG.md](plans/CHANGELOG.md): Per-build changelog                                                       |
+| **Dig into the archives**        | [RABBITHOLE.md](RABBITHOLE.md): Down you go...                                                                      |

--- a/README.md
+++ b/README.md
@@ -1,48 +1,56 @@
-[![VyOS LS1046A build](https://github.com/mihakralj/vyos-ls1046a-build/actions/workflows/auto-build.yml/badge.svg)](https://github.com/mihakralj/vyos-ls1046a-build/actions/workflows/auto-build.yml)
+[![VyOS LS1046A build](https://github.com/mihakralj/vyos-ls1046a-build/actions/workflows/self-hosted-build.yml/badge.svg)](https://github.com/mihakralj/vyos-ls1046a-build/actions/workflows/self-hosted-build.yml)
 
-# VyOS for NXP LS1046A (Mono Gateway)
+# VyOS for Mono Gateway Development Kit (NXP LS1046A)
 
-The [Mono Gateway Development Kit](https://github.com/ryneches/mono-gateway-docs) ships with OpenWrt. This build runs VyOS instead. That is the whole pitch.
+This repo builds VyOS for the aarch64 [Mono Gateway Development Kit](https://docs.mono.si/gateway-development-kit/hardware-description) based on latest [VyOS 1.5.x. 'rolling' release](https://vyos.net/get/nightly-builds/). New [builds](https://github.com/mihakralj/vyos-ls1046a-build/releases) are released each Friday 01:00 UTC.
 
-The hardware earns the effort. The NXP LS1046A brings four Cortex-A72 cores at 1.8 GHz, 8 GB of ECC DDR4, three RJ45 ports, two SFP+ cages, and a hardware Frame Manager that chews through packets before the CPU notices they arrived. NXP sells this chip to telecom carriers and switch vendors, not to people who want a friendly GUI. That gap is the opportunity.
+**This is the first and only VyOS build for bare-metal aarch64 networking hardware targeting support for both ASIC HW-offload *and* VPP.**
 
-**Thirteen things** broke on mainline VyOS before it would run on the LS1046A. All thirteen are fixed here, each documented below with its root cause.
+**The hardware earns the effort.** The Mono Gateway Development Kit is build around the [NXP LS1046A](https://www.nxp.com/docs/en/data-sheet/LS1046A.pdf) SoC - four Cortex-A72 cores at 1.6 GHz, with a hardware ASIC alongside which chews through packets before the CPU even notices they've arrived. The Mono Gateway Development Kit further adds 8 GB of ECC DDR4, three RJ45 ports, and two SFP+ cages - an ideal package for HW-offloaded, wire-speed networking on aarch64.
 
-## Get Started
+**Nothing in this class exists for use as a home router,** and that gap is an opportunity. Historically, NXP sold the LS1046A SoC to telecoms carriers and switch vendors, alongside a generalised [Application Solutions Kit (ASK)](https://www.nxp.com/design/design-center/software/embedded-software/software-for-industrial-networking/gateway-ask:VORTIQA-ASK) to control the HW-offload network accelerator functions. In developing the Gateway Development Kit, Mono purchased and with permission, [released the ASK source](https://github.com/we-are-mono/ASK) under GPL v2.0. 
 
-| I want to... | Go to |
-|---|---|
-| **Install VyOS** on the Mono Gateway | **[INSTALL.md](INSTALL.md)**: write USB image, `install image`, eMMC boot |
-| **Control hardware & diagnose problems** on a running system | [HWCTL.md](HWCTL.md): the `led` RGBW status-LED command (palette, fades, demo modes), LED/fan shell recipes, + the built-in diagnostic scripts (`dpaa1-check`, `sfp-check`, `fan-check`, `caam-check`, `xsk-zc-check`, `ask-check`, `vpp-check`, `firmware-check`) plus `support-bundle` — health probes for networking, SFP modules, thermals, crypto, AF_XDP/ASK, the boot firmware/FMan microcode chain, and one paste-ready preview bug report |
-| **Update board firmware** (bricked or fresh board) | [plans/FIRMWARE.md](plans/FIRMWARE.md): NOR + eMMC flash procedure, partition offset details |
-| **Understand the boot process & U-Boot** | [plans/BOOT-PROCESS.md](plans/BOOT-PROCESS.md): USB and eMMC paths, U-Boot env, memory map, clock tree, MTD layout, `booti` sequence, failure modes |
-| **See what changed** between releases | [plans/CHANGELOG.md](plans/CHANGELOG.md): per-build changelog |
+The LS1046A SoC uses the Data Path Acceleration Architecture (DPAA1), which defines the ASIC functions, and how they interoperate. 
+
+**VyOS enables pushing this hardware to its full potential now that aarch64 is becoming a first-class citizen in `1.5.x`.**  This repo documents the development of DPAA1/ASK HW-offloading rebuilt to modern standards as `ASK2`, and the compliment this can provide to Vector Packet Processing (VPP) on this HW.
+
+## Overview & Getting Started
+
+| **I want to...**                 | **Go to...**                                                                                                        |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| **Use VyOS** on the Mono Gateway | **[INSTALL.md](INSTALL.md)**: Start here                                                                            |
+| **Understand the HW**            | [HARDWARE.md](HARDWARE.md): Physical HW, boot-chain and known quirks                                                |
+| **Update the Firmware**          | [FIRMWARE.md](FIRMWARE.md): A *'how-to'* guide                                                                      |
+| **Control HW & diagnose issues** | [HWCTL.md](HWCTL.md):  Control the main LEDs with `led` & diagnose issues with the seven built-in `*-check` scripts |
+| **Understand HW-Offloading**     | [HW-OFFLOADING.md](HW-OFFLOADING.md): Overview of the DPAA1/ASK network architecture                                |
+| **Manage VyOS via a web UI**     | [VYMANAGER.md](VYMANAGER.md): Manage VyOS using the Vymanager SDN controller & web GUI                              |
+| **See how this started**         | [STARTING-GATE.md](STARTING-GATE.md): Getting mainline VyOS to work (at all)                                        |
+| **See what's changed**           | [plans/CHANGELOG.md](plans/CHANGELOG.md): Per-build changelog                                                       |
 
 > Review the [open issues](https://github.com/mihakralj/vyos-ls1046a-build/issues) before installing. Some limitations are permanent hardware constraints. Better to know before you're three hours into a rack installation.
-
 ## Architecture & Design
 
-The design specs and deep-dives behind the build. Start here to understand *how* it works, not just how to run it.
+The design specs and deep-dives behind the build. Start here to understand *how* it works, not just how to run it. Plans and Specs utilise [HADS](https://github.com/catcam/hads) to structure information.
 
-| Document | What's inside |
-|---|---|
-| [arch/README.md](arch/README.md) | **Hardware architecture reference index** — the in-repo distilled silicon reference (DPAA1/FMan v3/QMan/BMan/SEC): register-level facts, hardware constants, CCSR map, and per-module docs (`fman-pcd.md`, `fman-microcode-210-programming-reference.md`, `fman-pcd-api-reference.md`, `muram.md`, …) for when the NDA manuals aren't open |
+| Document                                                                           | What's inside                                                                                                                                                                                                                   |
+| ---------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | [specs/dpaa1-afxdp-modernization-spec.md](specs/dpaa1-afxdp-modernization-spec.md) | **DPAA1 AF_XDP driver modernization** — the flavor-ops abstraction, XSK-backed BMan pools, per-CPU NAPI on dedicated QMan channels, the four FMan HW offloads (CC / HM / Policer / CEETM), and the per-milestone status tracker |
-| [plans/NETWORKING-DEEP-DIVE.md](plans/NETWORKING-DEEP-DIVE.md) | **DPAA1 networking internals** — FMan architecture, QBMan portal allocation, the three-driver split (`fsl_dpaa_mac` / `fsl_dpa` / `fsl_dpaa_eth`), and how packets flow before the CPU sees them |
-| [plans/DUAL-DATAPLANE.md](plans/DUAL-DATAPLANE.md) | **Single-image dual-dataplane model** — one ISO ships every datapath; the silicon mode state machine (mainline/RSS ↔ ASK offload, with VPP as an AF_XDP overlay), runtime switching, and the reversibility contract |
-| [specs/ask2-rewrite-spec.md](specs/ask2-rewrite-spec.md) | **ASK2 hardware accelerator** — the modern in-tree rewrite of the FMan/QMan offload engine: `ask.ko`, the PCD subsystem, and independent per-interface IPv4/IPv6 controls (`set interfaces ethernet eth<n> offload ipv4|ipv6`) |
-| [specs/vpp-dpaa1-ls1046a-spec.md](specs/vpp-dpaa1-ls1046a-spec.md) | **VPP AF_XDP overlay** — kernel-bypass dataplane on the 10G SFP+ ports, thermal constraints, and the kernel↔VPP coexistence model |
-| [plans/PORTING.md](plans/PORTING.md) | **Porting postmortem** — driver archaeology, the boot-flow rework, and what broke (and why) bringing mainline VyOS up on the LS1046A |
+| [plans/NETWORKING-DEEP-DIVE.md](plans/NETWORKING-DEEP-DIVE.md)                     | **DPAA1 networking internals** — FMan architecture, QBMan portal allocation, the three-driver split (`fsl_dpaa_mac` / `fsl_dpa` / `fsl_dpaa_eth`), and how packets flow before the CPU sees them                                |
+| [specs/dual-dataplane.md](specs/dual-dataplane.md)                                 | **Single-image dual-dataplane model** — one ISO ships every datapath; the silicon mode state machine (mainline/RSS ↔ ASK offload, with VPP as an AF_XDP overlay), runtime switching, and the reversibility contract             |
+| [plans/ASK2-MASTER-PLAN.md](plans/ASK2-MASTER-PLAN.md)                             | **Understand work towards ASK2** — what ASK 1.x did right, what's changing in ASK2, and why                                                                                                                                     |
+| [specs/ask2-rewrite-spec.md](specs/ask2-rewrite-spec.md)                           | **ASK2 hardware accelerator** — the modern in-tree rewrite of the FMan/QMan offload engine: `ask.ko`, the PCD subsystem, and independent per-interface IPv4/IPv6 controls (`set interfaces ethernet eth offload ipv4 / ipv6`    |
+| [specs/vpp-dpaa1-ls1046a-spec.md](specs/vpp-dpaa1-ls1046a-spec.md)                 | **VPP AF_XDP overlay** — kernel-bypass dataplane on the 10G SFP+ ports, thermal constraints, and the kernel↔VPP coexistence model                                                                                               |
+| [plans/PORTING.md](plans/PORTING.md)                                               | **Porting postmortem** — driver archaeology, the boot-flow rework, and what broke (and why) bringing mainline VyOS up on the LS1046A                                                                                            |
 
 ## Build and Release Assets
 
 Built on demand via GitHub Actions (`workflow_dispatch` — trigger "VyOS LS1046A build (self-hosted)"; no schedule).
 
-| File | Description |
-|------|-------------|
-| `*-LS1046A-arm64.iso` | **Hybrid ISO** — boot from USB (`dd if=...iso of=/dev/sdX bs=4M`) for live install, or `add system image <url>` to upgrade an installed system |
-| `*-LS1046A-arm64.iso.minisig` | ISO signature ([verify key](data/vyos-ls1046a.minisign.pub)) |
-| `vyos-packages.tar` | Built kernel + vyos-1x `.deb` packages |
+| File                          | Description                                                                                                                                    |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `*-LS1046A-arm64.iso`         | **Hybrid ISO** — boot from USB (`dd if=...iso of=/dev/sdX bs=4M`) for live install, or `add system image <url>` to upgrade an installed system |
+| `*-LS1046A-arm64.iso.minisig` | ISO signature ([verify key](data/vyos-ls1046a.minisign.pub))                                                                                   |
+| `vyos-packages.tar`           | Built kernel + vyos-1x `.deb` packages                                                                                                         |
 
 ## What This Build Actually Delivers
 
@@ -71,171 +79,6 @@ This is, as far as anyone can tell, the only VyOS build targeting bare-metal ARM
 
 **Full FRRouting integration.** BGP, OSPF, IS-IS, BFD, MPLS, VXLAN, segment routing, PIM: all in the config tree with proper dependency resolution at commit time. Full stack, no glue scripts, no surprises.
 
-## Hardware
-
-| | |
-|---|---|
-| **SoC** | NXP QorIQ LS1046A: 4x Cortex-A72 @ 1.8 GHz, 8 GB DDR4 ECC |
-| **Network** | 5x DPAA1/FMan: 3x RJ45 (SGMII, Maxlinear GPY115C), 2x SFP+ (10GBase-R) |
-| **Storage** | 29.6 GB Kingston iNAND eMMC via eSDHC |
-| **Console** | 8250 UART at `0x21c0500`, 115200 baud (`ttyS0`) |
-| **Boot** | U-Boot 2025.04 via `booti`. EFI/GRUB is broken: DPAA1 reserved-memory OOM. |
-
-### Port Layout
-
-```mermaid
-block-beta
-  columns 7
-  block:rj45:3
-    columns 3
-    eth0["eth0\nRJ45\nSGMII"]
-    eth1["eth1\nRJ45\nSGMII"]
-    eth2["eth2\nRJ45\nSGMII"]
-  end
-  space
-  block:sfp:3
-    columns 3
-    eth3["eth3\nSFP+\n10GBase-R"]
-    space
-    eth4["eth4\nSFP+\n10GBase-R"]
-  end
-
-  style eth0 fill:#4a9,stroke:#333,color:#fff
-  style eth1 fill:#4a9,stroke:#333,color:#fff
-  style eth2 fill:#4a9,stroke:#333,color:#fff
-  style eth3 fill:#49a,stroke:#333,color:#fff
-  style eth4 fill:#49a,stroke:#333,color:#fff
-```
-
-As of firmware 2026-03-29+, the FMan MAC probe order matches physical port positions natively. No udev rename rule needed. Interface names map left-to-right as shown. On older firmware, eth0 was the rightmost port, which made staring at the front panel a Sudoku problem.
-
-### Boot Flow
-
-```mermaid
-flowchart LR
-  NOR["SPI NOR\n64 MB"] --> UB["U-Boot\n2025.04"]
-  UB -->|"booti"| K["Linux Kernel\n6.18.x-vyos"]
-  UB -.->|"❌ OOM"| EFI["GRUB/EFI"]
-  K --> LB["live-boot\ninitramfs"]
-  LB --> SQ["squashfs\n+ overlay"]
-  SQ --> VYOS["VyOS Router"]
-
-  subgraph eMMC ["eMMC (mmcblk0)"]
-    direction TB
-    FW["32 MB firmware zone"]
-    P1["p1: BIOS boot\n1 MB"]
-    P2["p2: EFI FAT32\n256 MB (unused)"]
-    P3["p3: ext4 root\n29.1 GB"]
-  end
-
-  UB -->|"ext4load\nmmc 0:3"| P3
-
-  style EFI fill:#a44,stroke:#333,color:#fff
-  style UB fill:#48a,stroke:#333,color:#fff
-  style K fill:#4a9,stroke:#333,color:#fff
-  style VYOS fill:#4a9,stroke:#333,color:#fff
-  style P2 fill:#666,stroke:#333,color:#aaa
-```
-
-The EFI/GRUB path is permanently broken: DPAA1 reserved-memory nodes in the device tree cause GRUB to OOM during `bootefi`. Nobody plans to fix it. `booti` works, costs nothing, and skips GRUB entirely. Sometimes the universe does you a favor.
-
-### DPAA1 Network Architecture
-
-```mermaid
-flowchart TB
-  subgraph CORES ["4× Cortex-A72"]
-    C0["Core 0"] & C1["Core 1"] & C2["Core 2"] & C3["Core 3"]
-  end
-
-  subgraph PORTALS ["Hardware Portals (1 per core)"]
-    BP["BMan\nBuffer Pool"] & QP["QMan\nQueue Manager"]
-  end
-
-  subgraph FMAN ["FMan (Frame Manager)"]
-    direction LR
-    M0["MEMAC 4\neth0 SGMII"]
-    M1["MEMAC 5\neth1 SGMII"]
-    M2["MEMAC 1\neth2 SGMII"]
-    M3["MEMAC 9\neth3 10G"]
-    M4["MEMAC 10\neth4 10G"]
-  end
-
-  subgraph PHY ["PHY Layer"]
-    direction LR
-    G0["GPY115C\nMDIO :00"] & G1["GPY115C\nMDIO :01"] & G2["GPY115C\nMDIO :02"]
-    S1["SFP+\nfixed-link"] & S2["SFP+\nfixed-link"]
-  end
-
-  CORES <-->|"dequeue/enqueue"| PORTALS
-  PORTALS <-->|"DMA"| FMAN
-  M0 --- G0
-  M1 --- G1
-  M2 --- G2
-  M3 --- S1
-  M4 --- S2
-
-  style FMAN fill:#2a6,stroke:#333,color:#fff
-  style PORTALS fill:#48a,stroke:#333,color:#fff
-```
-
-The Frame Manager is the unsung hero. It handles packet parsing, core distribution, and buffer management in hardware before the CPU ever touches a byte. LS1046A has four QMan/BMan software portals (one per A72 core), plus 28 pool channels and 4 dedicated channels the modernization work claims for per-qband AF_XDP dispatch.
-
-### DPAA1 Driver Modernization
-
-An ongoing effort modernizes the mainline DPAA1 driver into a single shared kernel binary (consumed in different runtime modes — kernel `default`, `vpp` AF_XDP, and `ask` FMan routing offload, all shipping in one image) with HW-accelerated AF_XDP and FMan/QMan hardware offloads. The ASK2 routing offload (IPv4 + IPv6 hardware forwarding, engaged per interface/family via `set interfaces ethernet eth<n> offload ipv4|ipv6`) is silicon-validated on all five ports. Full design and per-milestone status: [specs/dpaa1-afxdp-modernization-spec.md](specs/dpaa1-afxdp-modernization-spec.md) and [specs/ask2-rewrite-spec.md](specs/ask2-rewrite-spec.md).
-
-**Shipping and board-validated today:**
-
-- **Flavor-ops abstraction (M0)** — per-`dpaa_priv` ops tables, RCU-NULL-safe; byte-identical to mainline when no flavor module is loaded.
-- **AF_XDP zero-copy plumbing (M1–M3-3)** — `ndo_xsk_wakeup`, XSK-backed BMan pool, per-CPU NAPI + dedicated QMan channels per qband, cluster-aware pinning. Driver proven to drop **0%** at line rate; ~5.57 Gbit/s aggregate RX measured (bottleneck is the single userspace receiver, not the NIC).
-- **HW capability layer** — FMan PCD caps live-probed (`0x17` = CC HM POL PARSER on ucode 210).
-- **HM VLAN-strip offload (M3-3c)** — live on hardware (`ethtool -k` → `rx-vlan-offload: on`).
-- **Policer + CEETM scaffolds (M3-3d/e)** — install/stub APIs compiled in and cap-probed, stable contracts for the VyOS CLI consumers.
-
-**What remains for a feature-complete driver** (see the spec's "What remains for a complete DPAA1 driver" table):
-
-- **Two real kernel forward-ports** — the FMan PCD subsystem (unblocks CC steering and the productive HM/Policer datapaths) and the QMan-CEETM driver (~4500 LOC, absent from mainline 6.18, needed for HW egress shaping).
-- **Non-kernel glue** — vyos-1x CLI consumers for HM/Policer/CEETM, a traffic generator for the functional datapath gates, and a multi-core receiver to record the literal ≥7 Gbps figure.
-
-No further *architectural* work is required — the ops abstraction and capability layer already accommodate every remaining consumer.
-
-## What This Build Fixes
-
-Thirteen things were broken out of the box. Most failed silently. The worst ones looked like they worked but quietly hemorrhaged performance or dropped interfaces without a trace in dmesg.
-
-| # | Problem | Root Cause | Fix |
-|---|---------|------------|-----|
-| 1 | No eMMC | `MMC_SDHCI_OF_ESDHC` not set | `=y` |
-| 2 | No network | DPAA1 stack not enabled | `FSL_FMAN`, `DPAA`, `DPAA_ETH`, `BMAN`, `QMAN` `=y` + `XGMAC_MDIO` |
-| 3 | No console | `ttyAMA0` (PL011) instead of `ttyS0` (8250) | Patch + `earlycon` bootarg |
-| 4 | CPU at 700 MHz | `QORIQ_CPUFREQ=m` loads too late | `=y` + `CPU_FREQ_DEFAULT_GOV_PERFORMANCE` |
-| 5 | eth2 no link | Generic PHY, no SGMII AN workaround | `MAXLINEAR_GPHY=y` (GPY115C) |
-| 6 | No SFP+ | SFP framework + SerDes PHY missing | `SFP=y`, `PHYLINK=y`, `PHY_FSL_LYNX_10G=y` |
-| 7 | Wrong port order | DT probe order mismatched physical layout | DTS aliases + firmware-native MAC probe order (udev rule removed 2026-03-29) |
-| 8 | No auto-boot | `install image` only updates GRUB | `vyos-postinstall` + `fw_setenv` |
-| 9 | Jumbo frames broken | Module param used `fman` (wrong `KBUILD_MODNAME`) | `fsl_dpaa_fman.fsl_fm_max_frm=9600` |
-| 10 | Live mode false positive | `is_live_boot()` needs `BOOT_IMAGE=` (GRUB-only) | Patch 009: `vyos-union=/boot/` fallback |
-| 11 | kexec breaks HW init | `ln -sf /dev/null` broken by live-build | Chroot hook + SysV script removal |
-| 12 | No QSPI flash access | `CONFIG_SPI_FSL_QSPI` not set | `=y` + DTS partition map |
-| 13 | VPP capped at 3290 MTU | AF_XDP max frame ~3304 bytes on DPAA1 | Split-plane: VPP on SFP+ (no jumbo), kernel on RJ45 (full 9578 MTU) |
-
-Full postmortem with driver archaeology and DPAA1 architecture deep-dive: [plans/PORTING.md](plans/PORTING.md).
-
-## Known Boot Messages (Ignore These)
-
-The boot log contains some alarming lines. All of them are fine.
-
-| Message | Why It's Fine |
-|---------|---------------|
-| `smp_processor_id() in preemptible` | Cosmetic: PREEMPT_DYNAMIC on Cortex-A72. Suppressed in current builds. |
-| `could not generate DUID` | No persistent machine-id on live boot. Resolves after `install image`. |
-| `PCIe: no link` / `disabled` | No PCIe devices on this board. The bus exists. The devices do not. |
-| `WARNING failed to get smmu node` | No SMMU/IOMMU nodes in DTB. Harmless. |
-| `binfmt_misc.mount` FAILED | Expected on ARM64 target hardware. No binfmt emulation needed. |
-| kexec double-boot (USB live only) | Normal VyOS live-boot behavior. Installed eMMC systems boot once, straight through. |
-
-Full annotated boot sequences: [plans/BOOT-PROCESS.md](plans/BOOT-PROCESS.md).
-
 ## License
 
-VyOS sources are GPLv2. ARM64 builder image from [huihuimoe/vyos-arm64-build](https://github.com/huihuimoe/vyos-arm64-build). Hardware documentation from [mono-gateway-docs](https://github.com/ryneches/mono-gateway-docs).
+VyOS sources are GPL-2.0. ARM64 builder image from [huihuimoe/vyos-arm64-build](https://github.com/huihuimoe/vyos-arm64-build). Hardware documentation from [mono-gateway-docs](https://github.com/we-are-mono/docs/tree/master).

--- a/STARTING-GATE.md
+++ b/STARTING-GATE.md
@@ -1,0 +1,22 @@
+# Getting mainline VyOS to initially boot
+
+What breaks when you drop a generic VyOS ARM64 ISO onto NXP/Layerscape silicon, and the exact fixes that survived contact with the hardware. Thirteen things were broken out of the box. Most of the failures are silent, which is the part that costs you an afternoon. The worst ones looked like they worked but quietly haemorrhaged performance or dropped interfaces without a trace in dmesg.
+
+
+| #   | Problem                  | Root Cause                                        | Fix                                                                          |
+| --- | ------------------------ | ------------------------------------------------- | ---------------------------------------------------------------------------- |
+| 1   | No eMMC                  | `MMC_SDHCI_OF_ESDHC` not set                      | `=y`                                                                         |
+| 2   | No network               | DPAA1 stack not enabled                           | `FSL_FMAN`, `DPAA`, `DPAA_ETH`, `BMAN`, `QMAN` `=y` + `XGMAC_MDIO`           |
+| 3   | No console               | `ttyAMA0` (PL011) instead of `ttyS0` (8250)       | Patch + `earlycon` bootarg                                                   |
+| 4   | CPU at 700 MHz           | `QORIQ_CPUFREQ=m` loads too late                  | `=y` + `CPU_FREQ_DEFAULT_GOV_PERFORMANCE`                                    |
+| 5   | eth2 no link             | Generic PHY, no SGMII AN workaround               | `MAXLINEAR_GPHY=y` (GPY115C)                                                 |
+| 6   | No SFP+                  | SFP framework + SerDes PHY missing                | `SFP=y`, `PHYLINK=y`, `PHY_FSL_LYNX_10G=y`                                   |
+| 7   | Wrong port order         | DT probe order mismatched physical layout         | DTS aliases + firmware-native MAC probe order (udev rule removed 2026-03-29) |
+| 8   | No auto-boot             | `install image` only updates GRUB                 | `vyos-postinstall` + `fw_setenv`                                             |
+| 9   | Jumbo frames broken      | Module param used `fman` (wrong `KBUILD_MODNAME`) | `fsl_dpaa_fman.fsl_fm_max_frm=9600`                                          |
+| 10  | Live mode false positive | `is_live_boot()` needs `BOOT_IMAGE=` (GRUB-only)  | Patch 009: `vyos-union=/boot/` fallback                                      |
+| 11  | kexec breaks HW init     | `ln -sf /dev/null` broken by live-build           | Chroot hook + SysV script removal                                            |
+| 12  | No QSPI flash access     | `CONFIG_SPI_FSL_QSPI` not set                     | `=y` + DTS partition map                                                     |
+| 13  | VPP capped at 3290 MTU   | AF_XDP max frame ~3304 bytes on DPAA1             | Split-plane: VPP on SFP+ (no jumbo), kernel on RJ45 (full 9578 MTU)          |
+
+For a full post-mortem with driver archaeology and DPAA1 architecture deep-dives, see: [plans/PORTING.md](plans/PORTING.md).

--- a/VYMANAGER.md
+++ b/VYMANAGER.md
@@ -1,0 +1,467 @@
+# Using VyManager SDN controller & web GUI
+
+The primary source of truth for [VyManager](https://github.com/Community-VyProjects/VyManager) is the linked GitHub repo. This section provides a quick overview, and focuses on the specifics of use with the Mono Gateway Development kit.
+
+---
+
+## 1. VyOS: CLI-first, web GUI optional
+
+VyOS is a widely deployed enterprise-grade network operating system used at-scale across multiple cloud environments, virtualised deployments, and on a wide variety of 'bare metal' commodity hardware. A Graphical User Interface (GUI) in many cases is neither desired, or required, as VyOS is entirely configurable from the Command Line Interface (CLI).
+
+The VyOS API provides an alternative programmatic means to interact with one, or many VyOS instances at-scale, and enables the creation of a GUI, if desired. The addition of a new REST API in the (present) VyOS 1.5.x branch is credited with improving this further, resolving long-standing challenges in adequately exposing sufficient coverage of underlying VyOS capabilities.
+
+---
+
+## 2. VyManager: SDN controller & web GUI
+
+The [VyManager](https://github.com/Community-VyProjects/VyManager) community project provides a centralised Software Defined Networking (SDN) controller which enables the configuration, deployment and monitoring of multiple VyOS routers, across many-sites, all via a modern web interface. This is achieved by hooking the VyOS REST and GRAPHQL APIs, alongside enabling managed SSH access to provide additional interactive functionality, where required.
+
+### 2.1 VyManager architecture
+
+VyManager exists as three distinct component containers:
+
+- **Frontend –** A [node.js](https://en.wikipedia.org/wiki/Node.js) webapp written in [TypeScript](https://en.wikipedia.org/wiki/TypeScript), using Prisma [ORM](https://en.wikipedia.org/wiki/Object%E2%80%93relational_mapping)
+- **Backend –** A [python 3](https://en.wikipedia.org/wiki/History_of_Python#Version_3) based [FastAPI](https://en.wikipedia.org/wiki/FastAPI) client
+- **Database –** Vanilla [PostgreSQL](https://en.wikipedia.org/wiki/PostgreSQL) 16 [relational database management system](https://en.wikipedia.org/wiki/Relational_database_management_system "Relational database management system") (RDBMS)
+
+A more complete view of the tech stack used, see: [VyManager](https://github.com/Community-VyProjects/VyManager#tech-stack) 
+
+### 2.2 VyManager hosting
+
+The [VyManager](https://github.com/Community-VyProjects/VyManager) project provides a [Quick Start](https://github.com/Community-VyProjects/VyManager#quick-start) guide targeting [x86](https://en.wikipedia.org/wiki/X86) hosted [Docker](https://en.wikipedia.org/wiki/Docker_(software)) using `docker compose`. Other containerised environments like [Podman](https://en.wikipedia.org/wiki/Podman), via `podman-compose`, provide more modern alternative, utilising the same build artifacts. Alternative aarch64 hosting is also viable, and presents the option to deploy directly onto the Mono Gateway Development Kit, if desired.
+
+>**NOTE:** Pay close attention to the flagged [Security Considerations](https://github.com/Community-VyProjects/VyManager#security-considerations). VyManager is a privileged management interface, and should always be isolated and secured appropriately. The use of [rootless Podman configurations](https://developers.redhat.com/blog/2020/09/25/rootless-containers-with-podman-the-basics) should also be strongly preferred to rootful (run as root) container execution, e.g. with Docker.
+
+**Two deployment options will be addressed here:**
+
+1. Deployment via Podman onto generic [x86](https://en.wikipedia.org/wiki/X86) [COTS](https://en.wikipedia.org/wiki/Commercial_off-the-shelf) hardware
+
+2. Deployment via VyOS CLI, with Podman, onto the [aarch64](https://en.wikipedia.org/wiki/AArch64) Mono Gateway Development Kit
+
+---
+
+## 3. Common Requirements
+
+>**WARNING:** By default, the VyManager web GUI is globally accessible, on all ports, including any you define as 'WAN' interfaces. VyManager does have a 'trusted origins' concept, but this does not provide an effective security boundary. **Always ensure you configure [firewall](https://docs.vyos.io/en/rolling/configuration/firewall/index.html) policy appropriately, and that your wider configurational choices (e.g. a dedicated management interface and/or [VRF](https://docs.vyos.io/en/rolling/configuration/vrf/index.html)) to manage and mitigate the risk of unauthorised access.**
+
+In order for VyManager to access a running VyOS instance, we must configure an appropriate API key secret, and enable API access.
+
+Via the USB console or SSH: login to your running Mono GW VyOS instance and run:
+
+```bash
+openssl rand -hex 64 			# Generate random hex 64-char string
+```
+
+This 64-character string will be your API key. Make a secure record of it, e.g. in a password manager, as you will need it again shortly.
+
+>**NOTE:** The 64-char length is arbitrary, and length ≥32 characters will be sufficient for most use-cases.
+
+Now enter configuration mode, and enable API access:
+
+```bash
+# Enter configuration mode
+configure
+
+# Define the VyOS API key (replace <SECURE_API_KEY> with your generated API key)
+set service https api keys id vymanager key '<SECURE_API_KEY>'
+set service https api keys id vymanager key a1b2c3d4....		# Example
+
+# Enable the REST API (VyOS 1.5+ only)
+set service https api rest
+
+# Enable GraphQL API (required for dashboard streaming)
+set service https api graphql
+
+# Set GraphQL authentication to use the API key defined above
+set service https api graphql authentication type key
+
+# Commit, save & exit configuration mode
+commit;save;exit
+```
+
+>**NOTE:** As above, substitute the entirety of \<VARIABLE\> for your generated value, you should have no \< or \> characters in these files, when completed.
+
+VyOS will now respond to REST and GraphQL API endpoints when supplied with our API key. 
+
+Next steps will now depend on where VyManager itself will be hosted, see: §3.2 or §3.3
+
+## 4. Installation
+### 4.1 x86 hosting with `podman`
+
+>**NOTE: (Recommended option)** Using VyManager as the developers intended.
+
+This is a minor variation on the [Vymanager Quick Start](https://github.com/Community-VyProjects/VyManager#quick-start) guide, adapted.
+
+1) Ensure you have enabled the VyOS API in §3.1 
+
+2) Identify a suitable x86 host
+
+3) Install `podman` & `podman-compose`
+
+Depending on your host OS, the detailed instructions for will vary. A comprehensive set of guides are available in the documentation for [podman](https://podman.io/docs/installation) and the counterpart docs for [podman-compose](https://podman-desktop.io/docs/compose/setting-up-compose).
+
+4) Create a Vymanager folder, and enter it.
+
+```bash
+mkdir vymanager
+cd vymanager
+```
+
+5) Create a file named `docker-compose.yml`, and copy in the below contents, which you will need to then customised for your use in the next few steps:
+
+```yml
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: vymanager-postgres
+    environment:
+      POSTGRES_USER: vymanager
+      POSTGRES_PASSWORD: <POSTGRES_PASSWORD>
+      POSTGRES_DB: vymanager
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    restart: unless-stopped
+    networks:
+      - vymanager-network
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U vymanager -d vymanager"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s
+
+  backend:
+    image: ghcr.io/community-vyprojects/vymanager-backend:beta
+    container_name: vymanager-backend
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./certs:/usr/local/share/ca-certificates/custom:ro
+    env_file:
+      - .env
+    restart: unless-stopped
+    networks:
+      - vymanager-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/docs"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+
+  frontend:
+    image: ghcr.io/community-vyprojects/vymanager-frontend:beta
+    container_name: vymanager-frontend
+    ports:
+      - "3000:3000"
+    env_file:
+      - .env
+    depends_on:
+      backend:
+        condition: service_healthy
+      postgres:
+        condition: service_healthy
+    restart: unless-stopped
+    networks:
+      - vymanager-network
+
+networks:
+  vymanager-network:
+    driver: bridge
+
+volumes:
+  postgres_data:
+    driver: local
+```
+
+6) Create a separate `.env` file, and copy in the below config, which will be customised in the next step:
+
+```yml
+
+# HEX SECRETS
+SSH_ENCRYPTION_KEY=<SSH_KEY>
+
+DATABASE_URL=postgresql://vymanager:<POSTGRES_PASSWORD>@postgres:5432/vymanager
+FRONTEND_URL=http://frontend:3000
+
+# BASE64 SECRETS
+BETTER_AUTH_SECRET=<SHARED_SECRET>
+
+## WEB GUI URL
+BETTER_AUTH_URL=http://<SERVER_IP>:3000
+NEXT_PUBLIC_APP_URL=http://<SERVER_IP>:3000
+
+## ALLOWED LOGIN ORIGINS - comma-separated list - omit for global accesibility
+TRUSTED_ORIGINS=http://<SERVER_IP>:3000,http://localhost:3000
+
+### DEFINED ENV VARS + BACKEND NETWORK - NO CHANGES REQUIRED
+NODE_ENV=production
+VYMANAGER_ENV=production
+BACKEND_URL=http://backend:8000
+```
+
+Create and substitute `<SECRETS>` in the `.env` and `docker-compose.yml` with your own generated values. For this we will again make use of `openssl rand` to generate the secrets required.
+
+```bash 
+<SSH_KEY>					# Generate random hex 64-char string
+<POSTGRES_PASSWORD> 		# Generate random hex 64-char string
+<SHARED_SECRET>  			# Generate random base64 32 bit string
+
+# Generate random hex 64-char string
+openssl rand -hex 64
+
+# Generate random base64 32 bit string
+openssl rand -base64 32
+```
+
+>**NOTE:** As previously, substitute the entirety of \<VARIABLE\> for your generated value. You should have no "\<" or "\>" characters in these files once completed.
+
+>**NOTE:** The generated <POSTGRES_PASSWORD> ***MUST*** must the same and substituted into **BOTH** the `docker-compose.yml` **AND** the `.env` files
+
+10) Finally, define the `<SERVER_IP>` in the `.env` file at which you your Web GUI will be served
+
+This will be the IP of the host machine identified in step #1.
+
+>**NOTE:** VyManager has a 'TRUSTED_ORIGINS' concept, which if defined, will only allow GUI logins from a source IPs defined here in as a comma-separated list. This should ***NOT*** be relied upon as security control and does ***NOT*** prevent access to the login page.
+
+11) Build and start the three defined containers via:
+
+```bash
+# NB: unlike 'docker compose', 'podman-compose' is hypenated 
+
+podman-compose up -d				# Builds and deploys the defined containers
+```
+
+12) Access the VyManager web GUI at the defined in the `.env` file, and complete the initial on-boarding process to create a local admin account
+
+```
+http://<SERVER_IP>:3000 
+```
+
+13) The initial onboarding process will require creating a username + password. Ensure these are saved into a password manager in keeping with good practice.
+
+14) Define a 'Site' e.g. "Home"
+
+15) Create a new 'Instance' and define the following:
+
+**Basic info:**
+- Instance Name
+
+**Connection:**
+- Host IP
+- API Key (as defined in §3.1)
+
+**SSH / Monitoring:**
+- SSH username
+
+```
+
+16) Edit the newly added 'Instance' via the '3 dot' menu on the right, next to the 'Offline / Online' status indicator.
+
+Generate a SSH key, and copy the Vyos commands provided.
+
+Via the USB console or SSH: login to your running VyOS instance and run the indicated commands :
+```bash
+# Enter configuration mode
+configure
+
+# Define the SSH public key type for user <USER>
+set system login user <USER> authentication public-keys type ssh-ed25519
+
+# Define the VyManager SSH public key
+set system login user <USER> authentication public-keys vymanager key <VYMANAGER SSH PUB KEY HERE>
+
+# Apply, save to persistent config, exit configuration mode
+commit;save;exit
+
+```
+
+17) In the VyManager webUI, confirm you have applied the SSH config. If completed correctly, you will see a small green indicator and "SSH Key Configured". Save changes
+
+18) Connect to your VyOS instance, and begin configuring VyOS as you might any other Router with a WebUI.
+
+19) DONE!
+
+>**NOTE:** Thanks to the VyManager SSH key we've just created, you can use the webUI to access a console webshell, manage containers and much more.
+
+
+### 4.2 aarch64 hosting on-device
+
+>**NOTE: (Use with caution).** This adapts VyManager for the singular purpose of serving an on-device web GUI. It will require additional effort to deploy and use securely, given the inherently privileged and exposed position of a router in any network topology. 
+
+>**WARNING:** Unlike the x86 install guide there is no <SERVER_IP> variable, as this defaults to the loopback address (127.0.0.1) when installing directly on the VyOS instance. This is not secure by default as the VyManager web GUI is then globally accessible, on all ports, including any you define as 'WAN' interfaces. VyManager does have a 'trusted origins' concept, but this does NOT provide an effective security boundary. **Always configure [firewall](https://docs.vyos.io/en/rolling/configuration/firewall/index.html) policy appropriately first, before you connect WAN, and ensure that your wider configurational choices (e.g. a dedicated management interface and/or [VRF](https://docs.vyos.io/en/rolling/configuration/vrf/index.html)) manage and mitigate the risk of unauthorised access.**
+
+**Differences from x86 method in §4.1:**
+- Container images use the aarch64 architecture
+- Container definition uses the VyOS CLI's declarative syntax, not a `docker-compose.yml` file.
+
+This section provides a guide to deployment of VyManager, directly onto the Mono Gateway Developer Kit, for the sole purpose of administering a VyOS instance on this hardware.
+
+1) Ensure you have enabled the VyOS API in §3.1 
+
+2) Identify a suitable aarch64 host
+
+>**NOTE:** Theses same container sources can be used for other aarch64 hosts, e.g. a Raspberry Pi4/5 in conjunction with the deployment method shown previously in §4.1.
+
+3) (other aarch64 hosts only) Install `podman` & `podman-compose` 
+
+4. Via the USB console or SSH: login to your running Mono GW VyOS instance and run:
+
+```bash
+# In operational mode (default context post-login)
+mkdir -p /config/vymanager/db /config/vymanager/api
+add container image postgres:15-alpine
+add container image ghcr.io/mihakralj/vymanager-api:beta-arm64
+add container image ghcr.io/mihakralj/vymanager-ui:beta-arm64
+```
+
+5. Copy the below into a text editor:
+
+```bash
+# Enter configuration mode
+configure
+set service https api rest
+set service https api graphql
+set service https api graphql authentication type key
+
+# Using the VyOS API key created in §3.1
+set service https api keys id vymanager key <SECURE_API_KEY>
+
+# Configure the postgres db container
+set container name vymanager-db image 'postgres:15-alpine'
+set container name vymanager-db allow-host-networks
+set container name vymanager-db port db source '5432'
+set container name vymanager-db port db destination '5432'
+set container name vymanager-db environment POSTGRES_USER value 'vymanager'
+set container name vymanager-db environment POSTGRES_PASSWORD value '<POSTGRES_PASSWORD>'
+set container name vymanager-db environment POSTGRES_DB value 'vymanager'
+set container name vymanager-db volume db-data source '/config/vymanager/db'
+set container name vymanager-db volume db-data destination '/var/lib/postgresql/data'
+
+# Configure the vymanager-api container
+set container name vymanager-api image 'ghcr.io/mihakralj/vymanager-api:beta-arm64'
+set container name vymanager-api allow-host-networks
+set container name vymanager-api port api-port source '8000'
+set container name vymanager-api port api-port destination '8000'
+set container name vymanager-api volume ssh-keys source '/home/vyos/.ssh'
+set container name vymanager-api volume ssh-keys destination '/root/.ssh'
+set container name vymanager-api environment DATABASE_URL value 'postgresql://vymanager:<POSTGRES_PASSWORD>@127.0.0.1:5432/vymanager'
+set container name vymanager-api environment BETTER_AUTH_SECRET value '<SHARED_SECRET>'
+set container name vymanager-api environment BETTER_AUTH_URL value 'http://127.0.0.1:8000'
+set container name vymanager-api environment FRONTEND_URL value 'http://127.0.0.1:3000'
+set container name vymanager-api environment SSH_ENCRYPTION_KEY value '<SSH_KEY>'
+
+# Configure the vymanager-ui (frontend) container
+set container name vymanager-ui image 'ghcr.io/mihakralj/vymanager-ui:beta-arm64'
+set container name vymanager-ui allow-host-networks
+set container name vymanager-ui port web source '3000'
+set container name vymanager-ui port web destination '3000'
+set container name vymanager-ui environment BACKEND_URL value 'http://127.0.0.1:8000'
+set container name vymanager-ui environment BETTER_AUTH_SECRET value '<SHARED_SECRET>'
+set container name vymanager-ui environment BETTER_AUTH_URL value 'http://127.0.0.1:3000'
+set container name vymanager-ui environment DATABASE_URL value 'postgresql://vymanager:<POSTGRES_PASSWORD>@127.0.0.1:5432/vymanager'
+set container name vymanager-ui environment FRONTEND_URL value 'http://127.0.0.1:3000'
+set container name vymanager-ui environment TRUSTED_ORIGINS value 'http://127.0.0.1:3000,http://localhost:3000'
+set container name vymanager-ui environment NODE_ENV value 'production'
+set container name vymanager-ui environment VYMANAGER_ENV value 'production'
+set container name vymanager-ui environment SSH_ENCRYPTION_KEY value '<SSH_KEY>'
+```
+
+6. Generate your required secrets:
+
+This can be done on the VyOS instance in op mode, if desired.
+
+```bash 
+<SSH_KEY>					# Generate random hex 64-char string
+<POSTGRES_PASSWORD> 		# Generate random hex 64-char string
+<SHARED_SECRET>  			# Generate random base64 32 bit string
+
+# Generate random hex 64-char string
+openssl rand -hex 64
+
+# Generate random base64 32 bit string
+openssl rand -base64 32
+```
+
+>**NOTE:** As previously, substitute the entirety of \<VARIABLE\> for your generated value. You should have no "\<" or "\>" characters in these files once completed.
+
+7. Substitute the secrets generated in step 6. into the config in your text editor from step 5.
+
+8. Via the USB console or SSH: login to your running Mono GW VyOS instance:
+```
+# Paste your prepared configuration from your text editor into VyOS
+
+# commit (apply to running config); save (to persistent config); exit (back to operational mode)
+commit;save;exit
+```
+
+9. Establish Router IP - or define Interface IP via USB console
+
+If you have an existing router with DHCP, the connected VyOS interface will be reachable via this IP within your existing network.
+
+Alternatively, via the USB console, login to your running Mono GW VyOS instance and assign an IP to an interface, and connect to this directly to continue configuration.
+
+```bash
+# Example to configure a temporary IP address 10.1.99.99 to eth0
+configure
+set interfaces ethernet address 10.1.99.99/24
+
+commit;save;exit
+```
+
+10. Connect to VyManager via the IP of your Mono GW.
+
+```
+http://<ROUTER_IP>:3000 
+```
+
+11) The initial onboarding process will require creating a username + password. Ensure these are saved into a password manager in keeping with good practice.
+
+12) Define a 'Site' e.g. "Home"
+
+13) Create a new 'Instance' and define the following:
+
+**Basic info:**
+- Instance Name
+
+**Connection:**
+- Host IP
+- API Key (as defined in §3.1)
+
+**SSH / Monitoring:**
+- SSH username
+
+```
+
+16) Edit the newly added 'Instance' via the '3 dot' menu on the right, next to the 'Offline / Online' status indicator.
+
+Generate a SSH key, and copy the Vyos commands provided.
+
+Via the USB console or SSH: login to your running VyOS instance and run the indicated commands :
+```bash
+# Enter configuration mode
+configure
+
+# Define the SSH public key type for user <USER>
+set system login user <USER> authentication public-keys type ssh-ed25519
+
+# Define the VyManager SSH public key
+set system login user <USER> authentication public-keys vymanager key <VYMANAGER SSH PUB KEY HERE>
+
+# Apply, save to persistent config, exit configuration mode
+commit;save;exit
+
+```
+
+14) In the VyManager webUI, confirm you have applied the SSH config. If completed correctly, you will see a small green indicator and "SSH Key Configured". Save changes
+
+15) Connect to your VyOS instance, and begin configuring VyOS as you might any other Router with a WebUI.
+
+16) DONE!
+
+>**NOTE:** Thanks to the VyManager SSH key we've just created, you can use the webUI to access a console webshell, manage containers and much more.


### PR DESCRIPTION
Fork hard reset on 2026-08-23 to [839dd82](https://github.com/mihakralj/vyos-ls1046a-build/commit/839dd82ca64d290bfe33ee250ebdd890af96c15d)

Proposed post-PR state [docs-refresh](https://github.com/Daegara/vyos-ls1046a-build/tree/docs-refresh)

Working branch commits pre-squashed for clarity. Laundry list of working commits retained in [working branch](https://github.com/Daegara/vyos-ls1046a-build/commits/daegara/) for reference only.

Most content is new; existing content was re-merged against vyos-ls1046a-build/main to capture upstream changes.

**Highlights:**
- **README.md** - Shorter, now signposts content broken out into thematic subpages
- **HARDWARE.md** - An overview of the HW
- **HW-OFFLOADING.md** - An overview of DPAA1+ASK1 architecture, DPAA1 drivers and microcode versions
- **HWCTL.md** - Refactored for easy of discovery for bundled script/tools
- **FIRMWARE.md** - A guide to updating the firmware (Mono-imager, Firmware-helper, legacy methods)
- **VYMANAGER.md** - A guide to installing VyManager on (external) x86 host, or (Mono GW) aarch64